### PR TITLE
Easier API for Shape creation

### DIFF
--- a/src/runner/environment.js
+++ b/src/runner/environment.js
@@ -66,7 +66,13 @@ define([
       easing: easing,
       filter: filter,
       stage: stage,
-      version: version
+      version: version,
+      arc: Shape.arc,
+      circle: Shape.circle,
+      ellipse: Shape.ellipse,
+      rect: Shape.rect,
+      polygon: Shape.polygon,
+      star: Shape.star
     };
 
     this.assetLoader = assetLoader;

--- a/src/runner/shape.js
+++ b/src/runner/shape.js
@@ -9,7 +9,7 @@ define([
   './bitmap'
 ], function(
   Point, CurvedPath, SegmentHelper, DisplayObject, tools,
-  color, parseGradient, Bitmap
+  color, gradient, Bitmap
 ) {
   'use strict';
 
@@ -44,7 +44,7 @@ define([
   }
   function setFillGradient(grad) {
     if (grad) {
-      this._fillGradient = parseGradient(grad);
+      this._fillGradient = gradient(grad);
     } else {
       this._fillGradient = null;
     }
@@ -106,7 +106,7 @@ define([
   }
   function setLineGradient(grad) {
     if (grad) {
-      this._lineGradient = parseGradient(grad);
+      this._lineGradient = gradient(grad);
     } else {
       this._lineGradient = null;
     }
@@ -792,6 +792,43 @@ define([
     this._segments.length = 0;
     this._curve.clear();
     return this;
+  };
+
+  /**
+   * Applies a fillColor, fillImage or fillGradient to the shape
+   *
+   * @param {String|Number|LinearGradient|RadialGradient|Bitmap|color.RGBAColor}
+   *  fill The fillColor (see `color.parse`), fillImage or fillGradient
+   * @returns {Shape} The current Shape instance
+   */
+  proto.fill = function(fill) {
+    if (typeof fill === 'string' || typeof fill === 'number' || fill instanceof color.RGBAColor) {
+      return this.attr('fillColor', fill);
+    } else if (fill instanceof gradient.LinearGradient || fill instanceof gradient.RadialGradient) {
+      return this.attr('fillGradient', fill);
+    } else if (fill instanceof Bitmap) {
+      return this.attr('fillImage', fill);
+    }
+    throw Error('A fill of "' + fill + '" is not supported');
+  };
+
+  /**
+   * Applies a lineColor or lineGradient to the shape
+   *
+   * @param {String|Number|LinearGradient|RadialGradient|Bitmap|color.RGBAColor}
+   *  fill The fillColor (see `color.parse`), fillImage or fillGradient
+   * @returns {Shape} The current Shape instance
+   */
+  proto.line = function(line, lineWidth) {
+    if (lineWidth) {
+      this.attr('lineWidth', lineWidth);
+    }
+    if (typeof line === 'string' || typeof line === 'number' || line instanceof color.RGBAColor) {
+      return this.attr('lineColor', line);
+    } else if (line instanceof gradient.LinearGradient || line instanceof gradient.RadialGradient) {
+      return this.attr('lineGradient', line);
+    }
+    throw Error('A fill of "' + fill + '" is not supported');
   };
 
   //******************************** HELPER ************************************

--- a/test/shape-spec.js
+++ b/test/shape-spec.js
@@ -1,8 +1,9 @@
 require([
   'bonsai/runner/shape',
   'bonsai/runner/gradient',
+  'bonsai/runner/bitmap',
   './runner.js'
-], function(Shape, gradient) {
+], function(Shape, gradient, Bitmap) {
 
   var precision = new Number(12);
   precision.PRECISION = +precision;
@@ -551,6 +552,39 @@ require([
       expect(s.attr('lineGradient')).toBe(g);
       s.attr('lineGradient', null);
       expect(s.attr('lineGradient')).toBe(null);
+    });
+  });
+
+  describe('fill', function() {
+    it('Can set fillGradient, fillColor and fillImage', function() {
+      var s = new Shape,
+          grad = gradient.linear(0, ['red', 'purple']),
+          bitmap = new Bitmap('data:image/png,');
+      s.fill('red');
+      expect(s.attr('fillColor')).toBe(+color('red'));
+      s.fill('blue');
+      expect(s.attr('fillColor')).toBe(+color('blue'));
+      s.fill(grad);
+      expect(s.attr('fillColor')).toBe(+color('blue'));
+      expect(s.attr('fillGradient')).toBe(grad);
+      s.fill(bitmap);
+      expect(s.attr('fillColor')).toBe(+color('blue'));
+      expect(s.attr('fillGradient')).toBe(grad);
+      expect(s.attr('fillImage')).toBe(bitmap);
+    });
+  });
+
+  describe('line', function() {
+    it('Can set lineGradient and lineColor', function() {
+      var s = new Shape,
+          grad = gradient.linear(0, ['red', 'purple']);
+      s.line('red');
+      expect(s.attr('lineColor')).toBe(+color('red'));
+      s.line('blue');
+      expect(s.attr('lineColor')).toBe(+color('blue'));
+      s.line(grad);
+      expect(s.attr('lineColor')).toBe(+color('blue'));
+      expect(s.attr('lineGradient')).toBe(grad);
     });
   });
 


### PR DESCRIPTION
**(please discuss)**

Creating shapes is something that users will want to do very often. Filling a shape and applying a stroke are also pretty frequent use-cases. 

Currently `Shape` instances only support the generalised `attr` method with no convenience methods for the most common  use-cases.

This pull request would make shape creation look like this:

``` js
var a = rect(0, 0, 50, 50).fill('red').line('green', 2);
```

Instead of the current way:

``` js
var a = Shape.rect(0, 0, 50, 50).attr({
  fillColor: 'red',
  lineColor: 'green',
  lineWidth: 2
});
```

Three main changes:
- All `Shape.*` factories are exposed globally, including `rect`, `arc`, `star`, `circle` etc. (this might create annoying global conflicts for the user)
- `Shape#fill()`: can accept a color, a gradient or a bitmap as the fill.
- `Shape#line()`: can accept a color or a gradient, and a lineWidth as the 2nd argument.

Both `line()` and `fill()` are just setters. They're not getters. It would be impossible to implement them as getters because a shape can have multiple fill styles (a fillColor and a fillGradient, for example).

Exposing all factories might be a little bit too much though, as it further pollutes the global namespace. I'm okay to remove that... just wanted to see what people thought.

---

My reasoning is that we should provide convenient ways of doing the most common things. Currently the shape creation process is needlessly verbose.
