### PR TITLE
Fix some bugs related to SVG Filters.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v0.3.2
 -------------------
-
+* Fix a bug where SVG Filters are applied in wrong order.
+* Fix a bug where SVG Filter's region was too big.
+* Make use of SVG's feDropShadow Filter when supported by user-agent.
 
 v0.3.1 / 2012-08-01
 -------------------

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -28,7 +28,8 @@ define([
 
   // svgFilters
   var isFEColorMatrixEnabled = svgFilters.isFEColorMatrixEnabled,
-      colorApplyColorMatrix = svgFilters.colorApplyColorMatrix;
+      colorApplyColorMatrix = svgFilters.colorApplyColorMatrix,
+      filterElementsFromList = svgFilters.filterElementsFromList;
 
   // AssetController
   var fontIDs = AssetController.handlers.Font.fontIDs,
@@ -1277,10 +1278,12 @@ define([
     var filterDef;
     var signature = 'filter:';
 
+    // create signature
     signature += list.map(function(filter) {
       return filterToSignature(filter);
     }).join();
 
+    // compare signature with existing signatures
     if (signature in this.definitions) {
       // We already have an identical filter -- use it:
       filterDef = this.definitions[signature];
@@ -1314,24 +1317,10 @@ define([
     filterContainer.id = this._genDefUID();
 
     // handle filter specific stuff and get an array of <filter> elements back
-    list.forEach(function(item) {
-
-      // TODO: Have a attr on DisplayObjects to determine filter region
-      // For now, we provide a region *3 of the bounding box
-      filterContainer.setAttribute('height', 10);
-      filterContainer.setAttribute('width', 10);
-      filterContainer.setAttribute('x', -5);
-      filterContainer.setAttribute('y', -5);
-
-      var filter = svgFilters.create(item.type, item.value);
-      if (tools.isArray(filter)) {
-        for (var i = 0, m = filter.length; i < m; i++) {
-          filterContainer.appendChild(filter[i]);
-        }
-      } else {
-        filterContainer.appendChild(filter);
-      }
-    });
+    var filterElements = filterElementsFromList(list);
+    for (var i = 0, len = filterElements.length; i < len; i += 1) {
+      filterContainer.appendChild(filterElements[i]);
+    }
 
     this.svg.defs.appendChild(filterContainer);
     element.setAttribute('filter', 'url(#' + filterContainer.id + ')');

--- a/test/renderer/svg_filters-spec.js
+++ b/test/renderer/svg_filters-spec.js
@@ -4,7 +4,56 @@ require([
 ], function(svgFilters) {
   describe('svgFilters', function() {
 
-    /* tests are missing */
+    // the real typeof
+    var toString = {}.toString;
 
+    // a SVGElement
+    function createSVGElement(name) {
+      return document.createElementNS('http://www.w3.org/2000/svg', name);
+    }
+
+    describe('has a property `filterElementsFromList`', function() {
+      it('is a function', function() {
+        expect(typeof svgFilters.filterElementsFromList).toBe('function');
+      });
+      it('returns an empty array by default', function() {
+        expect(svgFilters.filterElementsFromList() instanceof Array).toBeTruthy();
+      });
+      it('returns an empty array when the instructions are unknown', function() {
+        var instructions = [{ type: 'megaFilter', value: 'big-number' }];
+        expect(svgFilters.filterElementsFromList(instructions)).toEqual([]);
+      });
+      it('returns an empty array when the instructions are invalid', function() {
+        var instructions = [{ typo: 'typo' }];
+        expect(svgFilters.filterElementsFromList(instructions)).toEqual([]);
+      });
+      it('returns an SVGFE…Element at index 0 when instructions are valid', function() {
+        var instructions = [{ type: 'sepia', value: 1 }];
+        var filter = svgFilters.filterElementsFromList(instructions)[0];
+        expect(toString.call(filter)).toMatch(/^\[object SVGFE\w+Element\]/);
+      });
+      it('returns an SVGFE…Element at index 1 when multiple instructions are passed', function() {
+        var instructions = [{ type: 'sepia', value: 1 }, { type: 'sepia', value: 1 }];
+        var filter = svgFilters.filterElementsFromList(instructions)[1];
+        expect(toString.call(filter)).toMatch(/^\[object SVGFE\w+Element\]/);
+      });
+    });
+
+    describe('has a property `containsFlattenFilter`', function() {
+      it('is a function', function() {
+        expect(typeof svgFilters.containsFlattenFilter).toBe('function');
+      });
+      it('returns false by default', function() {
+        expect(svgFilters.containsFlattenFilter()).toBeFalsy();
+      });
+      it('returns false when the passed filters do not flatten.', function() {
+        var filterList = ['aFilter'];
+        expect(svgFilters.containsFlattenFilter(filterList)).toBeFalsy();
+      });
+      it('returns true when the passed filters contain a flatten filter.', function() {
+        var filterList = [createSVGElement('feMerge')];
+        expect(svgFilters.containsFlattenFilter(filterList)).toBeTruthy();
+      });
+    });
   });
 });


### PR DESCRIPTION
- Fix a bug where SVG Filters are applied in wrong order.
- Fix a bug where SVG Filter's region was too big.
- Make use of SVG's feDropShadow Filter when supported by user-agent.
