### PR TITLE
Cleanup animation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,10 @@ v0.3.4
 * Fix #36 where filters couldn't be removed (thx @qfox)
 * Fix a bug where the filter-attribute wasn't removed
 * Fix a bug where Bitmaps weren't updated via "source"
+* Replace ES5's forEach by `tools.forEach` in Animation class.
+* Remove `Animation#setSubjects` and `Animation#setSubject`
+* Modify "simple" Animation example movie
+* Change `Animation#play` signiture (Remove parameters)
 
 v0.3.3
 -------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ v0.3.4
 * Replace ES5's forEach by `tools.forEach` in Animation class.
 * Remove `Animation#setSubjects` and `Animation#setSubject`
 * Modify "simple" Animation example movie
-* Change `Animation#play` signiture (Remove parameters)
+* Change `Animation#play` signature (Remove parameters)
 
 v0.3.3
 -------------------

--- a/example/library/movies/animation-simple.js
+++ b/example/library/movies/animation-simple.js
@@ -1,8 +1,16 @@
-/**
- * Animated attributes
- */
-var rectPath = bonsai.Path.rect(150, 150, 150, 150).attr({fillColor: 'red',strokeColor: 'green', strokeWidth: 5,});
+var aRect1 = new Rect(0, 0, 150, 150).fill('red').addTo(stage);
+var aRect2 = new Rect(0, 200, 150, 150).fill('green').addTo(stage);
+var aRect3 = new Rect(0, 400, 150, 150).fill('blue').addTo(stage);
 
-stage.addChild(rectPath);
+// How to animate a DisplayObject? Three different ways:
 
-rectPath.animate('1s', { x: 300 });
+// pass properties to animate
+aRect1.animate('1s', { x: 150 });
+
+// pass Animation instance to animate
+var aAnim = new Animation('1s', { x: 150 });
+aRect2.animate(aAnim);
+
+// pass Animation instance to animate
+var aAnim = new Animation('1s', { x: 150 });
+aAnim.addSubject(aRect3).play();

--- a/src/runner/animation/animation.js
+++ b/src/runner/animation/animation.js
@@ -19,6 +19,8 @@ define([
   'use strict';
 
   var mixin = tools.mixin;
+  var isArray = tools.isArray;
+  var forEach = tools.forEach;
 
   /**
    * Translations, in the form of:
@@ -407,11 +409,10 @@ define([
      *     methods.
      */
     addSubjects: function(subjects, strategy) {
-      var me = this;
-      subjects = tools.isArray(subjects) ? subjects : [subjects];
-      subjects.forEach(function(subject) {
-        me.addSubject(subject, strategy);
-      });
+      subjects = isArray(subjects) ? subjects : [subjects];
+      forEach(subjects, function(subject) {
+        this.addSubject(subject, strategy);
+      }, this);
       return this;
     },
 
@@ -436,7 +437,9 @@ define([
      * @param {Array} subjects Array of subjects to remove
      */
     removeSubjects: function(subjects) {
-      subjects.forEach(tools.hitch(this, 'removeSubject'));
+      forEach(subjects, function(subject) {
+        this.removeSubject(subject);
+      }, this);
       return this;
     },
 
@@ -453,7 +456,7 @@ define([
      */
     setSubjects: function(subjects, strategy) {
 
-      subjects = tools.isArray(subjects) ? subjects : [subjects];
+      subjects = isArray(subjects) ? subjects : [subjects];
 
       this.removeSubjects(this.subjects.map(function(subj) {
         return subj.subject;

--- a/src/runner/animation/animation.js
+++ b/src/runner/animation/animation.js
@@ -257,8 +257,6 @@ define([
     /**
      * Starts or resumes the animation.
      *
-     * Optionally changes the subject of the animation.
-     *
      * @returns {this}
      */
     play: function() {

--- a/src/runner/animation/animation.js
+++ b/src/runner/animation/animation.js
@@ -432,47 +432,6 @@ define([
     },
 
     /**
-     * Sets the subjects of the animation while wiping all current subjects
-     *
-     * @param {Object} subject
-     * @param {mixed} [strategy='attr'] The set/get strategy to use
-     *   - 'attr': The 'attr' method of the object is used (for DisplayObjects)
-     *   - 'prop': Normal property setting and getting is used
-     *   - Object with 'set(subject, values)' and 'get(subject)'
-     *     methods.
-     * @returns {this}
-     */
-    setSubjects: function(subjects, strategy) {
-
-      subjects = isArray(subjects) ? subjects : [subjects];
-
-      this.removeSubjects(this.subjects.map(function(subj) {
-        return subj.subject;
-      }));
-      this.addSubjects(subjects, strategy);
-
-      return this;
-    },
-
-    /**
-     * Sets the subject of the animation while wiping all current subjects
-     *
-     * @param {Object} subject
-     * @param {mixed} [strategy='attr'] The set/get strategy to use
-     *   - 'attr': The 'attr' method of the object is used (for DisplayObjects)
-     *   - 'prop': Normal property setting and getting is used
-     *   - Object with 'set(subject, values)' and 'get(subject)'
-     *     methods.
-     */
-    setSubject: function(subject, strategy) {
-      this.removeSubjects(this.subjects.map(function(subj) {
-        return subj.subject;
-      }));
-      this.addSubject(subject, strategy);
-      return this;
-    },
-
-    /**
      * A single step in an animation
      *
      * @param {number} progress Progress between 0 and 1

--- a/src/runner/animation/animation.js
+++ b/src/runner/animation/animation.js
@@ -259,21 +259,9 @@ define([
      *
      * Optionally changes the subject of the animation.
      *
-     * @param {Object} [subject]
-     * @param {mixed} [strategy='attr'] The set/get strategy to use
-     *   - 'attr': The 'attr' method of the object is used (for DisplayObjects)
-     *   - 'prop': Normal property setting and getting is used
-     *   - Object with 'set(subject, values)' and 'get(subject, propertyNames)'
-     *     methods.
      * @returns {this}
      */
-    play: function(subjects, strategy) {
-
-      var me = this;
-
-      if (subjects) {
-        this.addSubjects(subjects, strategy);
-      }
+    play: function() {
 
       if (!this.subjects) {
         throw new Error('Unspecified subjects.');

--- a/src/runner/display_object.js
+++ b/src/runner/display_object.js
@@ -761,7 +761,7 @@ define([
         animation = new Animation(clock, duration, properties, options);
       }
 
-      animation.play(this);
+      animation.addSubject(this).play();
       return this;
     }
   };

--- a/test/animation/animation-spec.js
+++ b/test/animation/animation-spec.js
@@ -94,13 +94,13 @@ require([
         var anim = createAnimation();
         var listener = jasmine.createSpy('listener');
         anim.on('play', listener);
-        anim.play({}, 'prop');
+        anim.play();
 
         expect(listener).toHaveBeenCalled();
       });
       it('should play', function() {
         var anim = createAnimation();
-        anim.play({}, 'prop');
+        anim.play();
         expect(anim.isPlaying).toBeTruthy();
       });
     });
@@ -110,14 +110,14 @@ require([
         var anim = createAnimation();
         var listener = jasmine.createSpy('listener');
         anim.on('pause', listener);
-        anim.play({}, 'prop');
+        anim.play();
         anim.pause();
 
         expect(listener).toHaveBeenCalled();
       });
       it('should stop', function() {
         var anim = createAnimation();
-        anim.play({}, 'prop');
+        anim.play();
         anim.pause();
         expect(anim.isPlaying).toBeFalsy();
       });
@@ -129,7 +129,7 @@ require([
         var result = 0;
         anim.on('beforebegin', function(){ result += 1; });
         anim.on('play', function(){ result *= 2; } );
-        anim.play({}, 'prop');
+        anim.play();
         expect(result).toBe(2);
       });
     });
@@ -199,7 +199,7 @@ require([
       var anim = createAnimation('50ms', {
         foo: 1000,
         bar: -777,
-        far: .053
+        far: 0.053
       });
       anim.setSubjects(subject, 'prop');
       anim.play();
@@ -207,7 +207,7 @@ require([
         anim.on('end', function() {
           expect(subject.foo).toBe(1000);
           expect(subject.bar).toBe(-777);
-          expect(subject.far).toBeCloseTo(.053);
+          expect(subject.far).toBeCloseTo(0.053);
           next();
         });
       });
@@ -252,7 +252,7 @@ require([
           next();
         });
       });
-    })
+    });
   });
 
   describe('Path - morphing', function() {
@@ -261,18 +261,18 @@ require([
       return segments.map(function(seg){
         return [].slice.call(seg).map(function(arg){
           return isNaN(arg) ? arg : arg.toFixed(5);
-        })
+        });
       });
     }
 
     describe('morphTo', function() {
 
-      var source = new Path().moveTo(01, 01).lineTo(100, 50).arcTo(10, 10, 0, 0, 0, 20, 20),
+      var source = new Path().moveTo(1, 1).lineTo(100, 50).arcTo(10, 10, 0, 0, 0, 20, 20),
           sourceClone = source.clone(),
           target = new Path().moveTo(20, 20).lineTo(200, 11).arcTo(22, 33, 0, 0, 0, 30, 30);
 
-      source.attr({strokeColor: 'red', opacity: .5});
-      target.attr({strokeColor: 'blue', opacity: .5});
+      source.attr({strokeColor: 'red', opacity: 0.5});
+      target.attr({strokeColor: 'blue', opacity: 0.5});
 
       it('Should morph a source to the target segments', function() {
 
@@ -290,7 +290,7 @@ require([
                 sensibleCopyOfSegments(target._segments)
               );
               expect(+source.attr('strokeColor')).toBe(+color('blue'));
-              expect(source.attr('opacity')).toBe(.5);
+              expect(source.attr('opacity')).toBe(0.5);
               next();
             }
           });

--- a/test/animation/animation-spec.js
+++ b/test/animation/animation-spec.js
@@ -79,16 +79,6 @@ require([
       });
     });
 
-    describe('setSubject', function() {
-      it('should set the subject of the animation', function() {
-        // NOTE: This will probably change.
-        var anim = createAnimation();
-        var obj = new DisplayObject();
-        anim.setSubject(obj);
-        expect(anim.subjects[0].subject).toBe(obj);
-      });
-    });
-
     describe('play', function() {
       it('should emit play event', function() {
         var anim = createAnimation();
@@ -158,7 +148,7 @@ require([
       var anim = new createAnimation('50ms', {
         foo: 1000
       });
-      anim.setSubjects(subject, 'prop');
+      anim.addSubject(subject, 'prop');
       anim.play();
       async(function(next) {
         anim.on('end', function() {
@@ -184,7 +174,7 @@ require([
         delay: '60ms'
       });
       expect(anim.delay).toBe(2);
-      anim.setSubjects(subject, 'prop');
+      anim.addSubject(subject, 'prop');
       anim.play();
       async(function(next) {
         anim.on('end', function() {
@@ -201,7 +191,7 @@ require([
         bar: -777,
         far: 0.053
       });
-      anim.setSubjects(subject, 'prop');
+      anim.addSubject(subject, 'prop');
       anim.play();
       async(function(next) {
         anim.on('end', function() {
@@ -222,7 +212,7 @@ require([
       var anim = createAnimation('50ms', {
         x: 500
       });
-      anim.setSubjects(subjects, 'prop');
+      anim.addSubjects(subjects, 'prop');
       anim.play();
       async(function(next) {
         anim.on('end', function() {
@@ -239,7 +229,7 @@ require([
       var anim = new createAnimation('50ms', {
         matrix: new Matrix(2,1,-1,1,150,200)
       });
-      anim.setSubjects(subject, 'prop');
+      anim.addSubjects(subject, 'prop');
       anim.play();
       async(function(next) {
         anim.on('end', function() {


### PR DESCRIPTION
The reason behind removing setSubject and setSubjects is that they're probably not going to be used. addSubject(s)/removeSubject(s) are more than sufficient for what we foresee as common usages of the Animation class. The other changes are general code clean-up.
