### PR TITLE
Use first changed touch for the non-multi event

### DIFF
--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -78,30 +78,25 @@ define([
           touchData = this.touchData || (this.touchData = {}),
           type = domEvent.type,
           identifier,
+          singleTouchData,
           touch;
-
-      if (allTouches && allTouches.length) {
-        // Fire the non-multi event for the very first event in the touch-list
-        allTouches[0].type = type;
-        this.handleSingleTouch(
-          allTouches[0],
-          touchData[allTouches[0].identifier] || (touchData[allTouches[0].identifier] = {}),
-          false
-        );
-      } 
 
       if (changedTouches && changedTouches.length) {
         // Go through new touch events and fire individually:
         for (var i = 0, l = changedTouches.length; i < l; ++i) {
           touch = changedTouches[i];
+          // Handle each touch individually:
+          identifier = touch.identifier;
           touch.type = type;
           touch.index = allTouches.indexOf(touch);
-          // Handle each touch individually:
-          this.handleSingleTouch(
-            touch,
-            touchData[touch.identifier] || (touchData[touch.identifier] = {}),
-            true
-          );
+
+          singleTouchData = touchData[identifier] || (touchData[identifier] = {});
+          this.handleSingleTouch(touch, singleTouchData, true);
+
+          // Fire the non-multi event for the very first event in the touch-list
+          if (i === 0) {
+            this.handleSingleTouch(touch, singleTouchData, false);
+          }
         }
       }
     },


### PR DESCRIPTION
Using `domEvent.touches[0]` for the non-`'multi:*'` events fails for `'touchend'` and `'touchcancel'`, because said list is empty when e.g. releasing a single finger.

Changing to `domEvent.changedTouches[0]` solves this problem and is probably more accurate for `'touchstart'` as well.
