### PR TITLE
Set textOrigin to be 'top' by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ v0.3.7
 -------------------
 * Fix issue where click event would be fired twice on touch devices (#60)
 * Change display list implementation from mixin to composition
+* Make the default textOrigin in the Text class 'top'
 
 v0.3.6 / 2012-09-12
 -------------------

--- a/src/runner/text.js
+++ b/src/runner/text.js
@@ -131,7 +131,7 @@ define([
       _miterLimit: data(4, true),
       miterLimit: accessor(getMiterLimit, setMiterLimit, true),
       text: accessor(getText, setText, true),
-      textOrigin: data(null, true, true),
+      textOrigin: data('top', true, true),
       selectable: data(true, true, true)
     });
 

--- a/test/text-spec.js
+++ b/test/text-spec.js
@@ -18,6 +18,10 @@ require([
         expect(new Text(false).attr('text')).toBe('false');
       });
 
+      it('Expect default textOrigin to be "top"', function() {
+        expect(new Text('').attr('textOrigin')).toBe('top');
+      });
+
       it('sets text via attr() and get text', function() {
         var ex = 'myTest', t = new Text('').attr('text', ex);
         expect(t.attr('text')).toBe(ex);


### PR DESCRIPTION
Changes in transwf are also required. See: https://github.com/uxebu/transwf/pull/166

This was discussed a while ago. To make the Text API more intuitive the `{x,y}` attributes of a Text instance should be where the top-left of the Text appears on screen, not the bottom-left (as it previously was).
