### PR TITLE
Categorized messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v0.3.9
 -------------------
 
+* Add optional category to sendMessage() to allow for more specific message passing
+
 
 v0.3.8 / 2012-09-28
 -------------------

--- a/example/library/movies/audio-button.js
+++ b/example/library/movies/audio-button.js
@@ -17,7 +17,8 @@ new Button('Boooom!', 50, 50).on('click', function() {
 
 // BUTTON IMPLEMENTATION
 function Button(text, x, y) {
-  var button = new bonsai.Group().addTo(stage).attr({x: x, y: y})
+
+  var button = new bonsai.Group().addTo(stage).attr({x: x, y: y});
 
   button.bg = bonsai.Path.rect(0, 0, 100, 40, 5).attr({
     fillGradient: bonsai.gradient.radial(['#19D600', '#0F8000'], 100, 50, -20),
@@ -30,13 +31,13 @@ function Button(text, x, y) {
       button.bg.animate('.2s', {
         fillGradient: bonsai.gradient.radial(['#9CFF8F', '#0F8000'], 100, 50, -20),
         strokeWidth: 3
-      })
+      });
     })
     .on('mouseout', function() {
       button.bg.animate('.2s', {
         fillGradient: bonsai.gradient.radial(['#19D600', '#0F8000'], 100, 50, -20),
         strokeWidth: 0
-      })
+      });
     });
 
   button.text = new bonsai.Text(text).attr({

--- a/example/library/movies/movie_list.js
+++ b/example/library/movies/movie_list.js
@@ -134,7 +134,8 @@ movieList = {
     'shape-arc.js',
     'shape-getPointAtLength.js',
     'shape-center-of-arc.js',
-    'shape-fill-rule.js'
+    'shape-fill-rule.js',
+    'overlapping-paths.js'
   ],
   'Test': [
     'text.js',

--- a/example/library/movies/overlapping-paths.js
+++ b/example/library/movies/overlapping-paths.js
@@ -1,0 +1,11 @@
+// http://jsbin.com/ociyiw/24/edit
+
+new Rect(100, 100, 100, 100).fill("yellow").attr({opacity:0.5}).addTo(stage);
+new Rect(160, 100, 100, 100).fill("green").attr({opacity:0.5}).addTo(stage);
+
+var group = new Group().addTo(stage).attr({
+  y:120,
+  opacity:0.5
+});
+new Rect(100, 100, 100, 100).fill("yellow").addTo(group);
+new Rect(160, 100, 100, 100).fill("green").addTo(group);

--- a/example/library/movies/pong.js
+++ b/example/library/movies/pong.js
@@ -4,7 +4,7 @@ var Pong, audioSprite;
  * PONG
  */
 
-Pong = (function(){
+Pong = (function() {
 
   /**
    * Setup default settings

--- a/src/asset/audio_handler.js
+++ b/src/asset/audio_handler.js
@@ -79,7 +79,12 @@ define([
     audioElement.load();
     this.registerElement(audioElement);
 
-    audioElement.addEventListener(events[loadLevel], doDone, false);
+    // don't send *DOM* Events to the runner
+    function onload() {
+      doDone();
+    }
+
+    audioElement.addEventListener(events[loadLevel], onload, false);
   };
 
   return AudioHandler;

--- a/src/renderer/renderer_controller.js
+++ b/src/renderer/renderer_controller.js
@@ -201,11 +201,8 @@ function(tools, EventEmitter, URI) {
           this.assetController.destroy(messageData.id);
           break;
         case 'message':
-          var category = message.category;
-          if (category) {
-            this
-              .emit('message:' + category, messageData)
-              .emit('message', messageData, category);
+          if ('category' in message) {
+            this.emit('message:' + message.category, messageData);
           } else {
             this.emit('message', messageData);
           }
@@ -313,14 +310,14 @@ function(tools, EventEmitter, URI) {
      */
     sendMessage: function(category, messageData) {
       if (arguments.length < 2) {
-        messageData = category;
-        category = null;
+        this.post('message', category);
+      } else {
+        this.runnerContext.notifyRunner({
+          command: 'message',
+          category: category,
+          data: messageData
+        });
       }
-      this.runnerContext.notifyRunner({
-        command: 'message',
-        category: category,
-        data: messageData
-      });
       return this;
     },
 

--- a/src/renderer/renderer_controller.js
+++ b/src/renderer/renderer_controller.js
@@ -201,7 +201,14 @@ function(tools, EventEmitter, URI) {
           this.assetController.destroy(messageData.id);
           break;
         case 'message':
-          this.emit('message', messageData);
+          var category = message.category;
+          if (category) {
+            this
+              .emit('message:' + category, messageData)
+              .emit('message', messageData, category);
+          } else {
+            this.emit('message', messageData);
+          }
           break;
         case 'isReady':
           this.isRunnerListening = true;
@@ -299,11 +306,22 @@ function(tools, EventEmitter, URI) {
 
     /**
      * Sends a message to the RunnerContext / stage
+     *
+     * @param [category=null] The message category
      * @param messageData
      * @returns {this} The instance
      */
-    sendMessage: function(messageData) {
-      return this.post('message', messageData);
+    sendMessage: function(category, messageData) {
+      if (arguments.length < 2) {
+        messageData = category;
+        category = null;
+      }
+      this.runnerContext.notifyRunner({
+        command: 'message',
+        category: category,
+        data: messageData
+      });
+      return this;
     },
 
     /**

--- a/src/runner/stage.js
+++ b/src/runner/stage.js
@@ -149,11 +149,8 @@ define([
           this.env.exports.env.emit('change', data);
           break;
         case 'message':
-          var category = message.category;
-          if (category) {
-            this
-              .emit('message:' + category, data)
-              .emit('message', data, category);
+          if ('category' in message) {
+            this.emit('message:' + message.category, data);
           } else {
             this.emit('message', data);
           }
@@ -361,13 +358,18 @@ define([
      * @returns {this} The instance
      */
     sendMessage: function(category, messageData) {
-      var hasCategory = arguments.length > 1;
-      var message = {
-        command: 'message',
-        category: hasCategory ? category : null,
-        data: hasCategory ? messageData : category
-      };
-      return this.post(message);
+      if (arguments.length > 1) {
+        return this.post({
+          command: 'message',
+          category: category,
+          data: messageData
+        });
+      } else {
+        return this.post({
+          command: 'message',
+          data: category
+        });
+      }
     },
 
     /**

--- a/src/runner/stage.js
+++ b/src/runner/stage.js
@@ -149,7 +149,14 @@ define([
           this.env.exports.env.emit('change', data);
           break;
         case 'message':
-          this.emit('message', data);
+          var category = message.category;
+          if (category) {
+            this
+              .emit('message:' + category, data)
+              .emit('message', data, category);
+          } else {
+            this.emit('message', data);
+          }
           break;
         case 'canRender':
           this._canRender = true;
@@ -348,11 +355,19 @@ define([
 
     /**
      * Sends a message to the renderer / stage controller
+     *
+     * @param [category=null] The message category
      * @param messageData
      * @returns {this} The instance
      */
-    sendMessage: function(messageData) {
-      return this.post({command: 'message', data: messageData});
+    sendMessage: function(category, messageData) {
+      var hasCategory = arguments.length > 1;
+      var message = {
+        command: 'message',
+        category: hasCategory ? category : null,
+        data: hasCategory ? messageData : category
+      };
+      return this.post(message);
     },
 
     /**

--- a/test/common/mock.js
+++ b/test/common/mock.js
@@ -2,7 +2,7 @@ define(function() {
   'use strict';
 
   function createSpy(name) {
-    return jasmine.createSpy(name)
+    return jasmine.createSpy(name);
   }
 
   function createEventEmitter() {
@@ -10,7 +10,7 @@ define(function() {
       on: createSpy('on'),
       addListener: createSpy('addListener'),
       removeListener: createSpy('removeListener')
-    }
+    };
   }
 
   var displayObjectId = 0;
@@ -21,7 +21,7 @@ define(function() {
         add: createSpy('add'),
         clear: createSpy('clear'),
         remove: createSpy('remove')
-      }
+      };
     },
 
     createDisplayObject: function() {
@@ -54,7 +54,7 @@ define(function() {
           needsDraw: {},
           needsInsertion: {}
         }
-      }
+      };
     }
-  }
+  };
 });

--- a/test/common/mock.js
+++ b/test/common/mock.js
@@ -39,6 +39,7 @@ define(function() {
 
     createMessageProxy: function() {
       var messageProxy = createEventEmitter();
+      messageProxy.notifyRenderer = jasmine.createSpy('notifyRenderer');
       return messageProxy;
     },
 

--- a/test/renderer_controller-spec.js
+++ b/test/renderer_controller-spec.js
@@ -309,6 +309,88 @@ define([
         expect(mockRunner.notifyRunner).toHaveBeenCalledWithCommand(command, commandData);
       });
     });
+
+    describe('sendMessage', function() {
+      var rendererController;
+      beforeEach(function() {
+        rendererController = createRendererController();
+      });
+      function getFirstArg() {
+        return mockRunner.notifyRunner.mostRecentCall.args[0];
+      }
+
+      it('should send an uncategorized message when called with one argument', function() {
+        var message = {};
+
+        rendererController.sendMessage(message);
+        var arg = getFirstArg();
+
+        expect(arg.command).toBe('message');
+        expect(arg.data).toBe(message);
+        expect(arg.category).toBeFalsy();
+      });
+
+      it('should send a categorized message when called with two arguments', function() {
+        var message = {};
+        var messageCategory = 'arbitrary';
+
+        rendererController.sendMessage(messageCategory, message);
+        var arg = getFirstArg();
+
+        expect(arg.command).toBe('message');
+        expect(arg.data).toBe(message);
+        expect(arg.category).toBe(messageCategory);
+      });
+
+    });
+
+    describe('message events', function() {
+      var rendererController;
+      beforeEach(function() {
+        rendererController = createRendererController();
+      });
+
+      it('should emit uncategorized messages to uncategorized listeners only', function() {
+        var uncategorizedListener = jasmine.createSpy('uncategorized');
+        var undefinedCategoryListener = jasmine.createSpy('undefined');
+        var messageData = {};
+        rendererController.on('message', uncategorizedListener);
+        rendererController.on('message:undefined', undefinedCategoryListener);
+
+        rendererController.handleEvent({command: 'message', data: messageData});
+
+        expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
+        expect(undefinedCategoryListener).not.toHaveBeenCalled();
+      });
+
+      it('should emit uncategorized messages to uncategorized listeners only', function() {
+        var uncategorizedListener = jasmine.createSpy('uncategorized');
+        var nullCategoryListener = jasmine.createSpy('null');
+        var messageData = {};
+        rendererController.on('message', uncategorizedListener);
+        rendererController.on('message:null', nullCategoryListener);
+
+        rendererController.handleEvent({command: 'message', data: messageData, category: null});
+
+        expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
+        expect(nullCategoryListener).not.toHaveBeenCalled();
+      });
+
+      it('should emit categorized messages to both categorized and uncategorized listenerts', function() {
+        var uncategorizedListener = jasmine.createSpy('uncategorized');
+        var categorizedListener = jasmine.createSpy('categorized');
+        var messageData = {};
+        var category = 'arbitrary';
+        rendererController.on('message', uncategorizedListener);
+        rendererController.on('message:' + category, categorizedListener);
+
+        rendererController.handleEvent({command: 'message', data: messageData, category: category});
+
+        expect(uncategorizedListener).toHaveBeenCalledWith(messageData, category);
+        expect(categorizedListener).toHaveBeenCalledWith(messageData);
+      });
+
+    });
   });
 
 });

--- a/test/renderer_controller-spec.js
+++ b/test/renderer_controller-spec.js
@@ -363,7 +363,7 @@ define([
         expect(undefinedCategoryListener).not.toHaveBeenCalled();
       });
 
-      it('should emit uncategorized messages to uncategorized listeners only', function() {
+      it('should emit a message with category "null" to categorized listeners only', function() {
         var uncategorizedListener = jasmine.createSpy('uncategorized');
         var nullCategoryListener = jasmine.createSpy('null');
         var messageData = {};
@@ -372,11 +372,11 @@ define([
 
         rendererController.handleEvent({command: 'message', data: messageData, category: null});
 
-        expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
-        expect(nullCategoryListener).not.toHaveBeenCalled();
+        expect(uncategorizedListener).not.toHaveBeenCalled();
+        expect(nullCategoryListener).toHaveBeenCalledWith(messageData);
       });
 
-      it('should emit categorized messages to both categorized and uncategorized listenerts', function() {
+      it('should emit categorized messages to categorized listeners only', function() {
         var uncategorizedListener = jasmine.createSpy('uncategorized');
         var categorizedListener = jasmine.createSpy('categorized');
         var messageData = {};
@@ -386,7 +386,7 @@ define([
 
         rendererController.handleEvent({command: 'message', data: messageData, category: category});
 
-        expect(uncategorizedListener).toHaveBeenCalledWith(messageData, category);
+        expect(uncategorizedListener).not.toHaveBeenCalled();
         expect(categorizedListener).toHaveBeenCalledWith(messageData);
       });
 

--- a/test/stage-spec.js
+++ b/test/stage-spec.js
@@ -164,6 +164,90 @@ define([
 
       });
 
+      describe('sendMessage', function() {
+        var messageProxy, stage;
+        function getFirstArg() {
+          return messageProxy.notifyRenderer.mostRecentCall.args[0];
+        }
+        beforeEach(function(argument) {
+          messageProxy = mock.createMessageProxy();
+          stage = new Stage(messageProxy);
+        });
+
+        it('should send an uncategorized message when called with one argument', function() {
+          var message = {};
+
+          stage.sendMessage(message);
+          var arg = getFirstArg();
+
+          expect(arg.command).toBe('message');
+          expect(arg.data).toBe(message);
+          expect(arg.category).toBeFalsy();
+        });
+
+        it('should send a categorized message when called with two arguments', function() {
+          var message = {};
+          var messageCategory = 'arbitrary';
+
+          stage.sendMessage(messageCategory, message);
+          var arg = getFirstArg();
+
+          expect(arg.command).toBe('message');
+          expect(arg.data).toBe(message);
+          expect(arg.category).toBe(messageCategory);
+        });
+
+      });
+
+      describe('message events', function() {
+        var messageProxy, stage;
+        beforeEach(function(argument) {
+          messageProxy = mock.createMessageProxy();
+          stage = new Stage(messageProxy);
+        });
+
+        it('should emit uncategorized messages to uncategorized listeners only', function() {
+          var uncategorizedListener = jasmine.createSpy('uncategorized');
+          var undefinedCategoryListener = jasmine.createSpy('undefined');
+          var messageData = {};
+          stage.on('message', uncategorizedListener);
+          stage.on('message:undefined', undefinedCategoryListener);
+
+          stage.handleEvent({command: 'message', data: messageData});
+
+          expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
+          expect(undefinedCategoryListener).not.toHaveBeenCalled();
+        });
+
+        it('should emit uncategorized messages to uncategorized listeners only', function() {
+          var uncategorizedListener = jasmine.createSpy('uncategorized');
+          var nullCategoryListener = jasmine.createSpy('null');
+          var messageData = {};
+          stage.on('message', uncategorizedListener);
+          stage.on('message:null', nullCategoryListener);
+
+          stage.handleEvent({command: 'message', data: messageData, category: null});
+
+          expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
+          expect(nullCategoryListener).not.toHaveBeenCalled();
+        });
+
+        it('should emit categorized messages to both categorized and uncategorized listenerts', function() {
+          var uncategorizedListener = jasmine.createSpy('uncategorized');
+          var categorizedListener = jasmine.createSpy('categorized');
+          var messageData = {};
+          var category = 'arbitrary';
+          stage.on('message', uncategorizedListener);
+          stage.on('message:' + category, categorizedListener);
+
+          stage.handleEvent({command: 'message', data: messageData, category: category});
+
+          expect(uncategorizedListener).toHaveBeenCalledWith(messageData, category);
+          expect(categorizedListener).toHaveBeenCalledWith(messageData);
+        });
+
+      });
+
     });
 
   });

--- a/test/stage-spec.js
+++ b/test/stage-spec.js
@@ -219,7 +219,7 @@ define([
           expect(undefinedCategoryListener).not.toHaveBeenCalled();
         });
 
-        it('should emit uncategorized messages to uncategorized listeners only', function() {
+        it('should emit messages with category "null" to categorized listeners only', function() {
           var uncategorizedListener = jasmine.createSpy('uncategorized');
           var nullCategoryListener = jasmine.createSpy('null');
           var messageData = {};
@@ -228,11 +228,11 @@ define([
 
           stage.handleEvent({command: 'message', data: messageData, category: null});
 
-          expect(uncategorizedListener).toHaveBeenCalledWith(messageData);
-          expect(nullCategoryListener).not.toHaveBeenCalled();
+          expect(uncategorizedListener).not.toHaveBeenCalled();
+          expect(nullCategoryListener).toHaveBeenCalledWith(messageData);
         });
 
-        it('should emit categorized messages to both categorized and uncategorized listenerts', function() {
+        it('should emit categorized messages to categorized listeners only', function() {
           var uncategorizedListener = jasmine.createSpy('uncategorized');
           var categorizedListener = jasmine.createSpy('categorized');
           var messageData = {};
@@ -242,7 +242,7 @@ define([
 
           stage.handleEvent({command: 'message', data: messageData, category: category});
 
-          expect(uncategorizedListener).toHaveBeenCalledWith(messageData, category);
+          expect(uncategorizedListener).not.toHaveBeenCalled();
           expect(categorizedListener).toHaveBeenCalledWith(messageData);
         });
 


### PR DESCRIPTION
- Is backwards compatible to the current signature of `sendMessage()`
- Adds optional `category` parameter to `sendMessage`
- categorized messages trigger a `'message:<category>'` event
- is the “small solution” described in #79
- should make uxebu/bonsai-docs#20 easier
