### PR TITLE
Alternative method signature for `new Matrix()`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ v0.4.1
 * Fixed examples to be in line with the documentation.
 * Fix out-of-range hsl color values
 * Fix out-of-range alpha values when parsing rgba() strings
+* Add additional method signature for new Matrix([a, b, c, d, tx, ty]) 
+* Add Matrix.fromString() method to create new Matrix instance from a string.
 
 v0.4.0 / 2012-10-03
 -------------------

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -241,5 +241,9 @@ define([
     }
   };
 
+  Matrix.fromString = function (matrixString) {
+    return new Matrix(matrixString.match(/[^matrix(,)]+/g).map(Number));
+  }
+
   return Matrix;
 });

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -11,7 +11,7 @@ define([
    * @constructor
    * @name Matrix
    *
-   * @param {number} a Horizontal/x scale
+   * @param {number|string} a Horizontal/x scale or matrix string "matrix(0,1,0,0,1,1)"
    * @param {number} b Vertical/y skew
    * @param {number} c Horizontal/x skew
    * @param {number} d Vertical/y scale
@@ -19,6 +19,11 @@ define([
    * @param {number} ty Vertical/y translation
    */
   function Matrix(a, b, c, d, tx, ty) {
+    if ('string' === typeof a && a.match(/^matrix/)) {
+      var args = a.match(/[^a-z(),]+/g).map(function(i) { return +i });
+      return Matrix.apply(this, args);
+    }
+
     this.a = a != null ? a : 1;
     this.b = b || 0;
     this.c = c || 0;

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -241,6 +241,12 @@ define([
     }
   };
 
+  /**
+   * Creates a new Matrix from a matrix string: `'matrix(1,1,0,0,1,1)'`
+   *
+   * @param {string} matrixString The matrix string.
+   * @returns {Matrix} The instance.
+   */
   Matrix.fromString = function (matrixString) {
     return new Matrix(matrixString.match(/[^matrix(,)]+/g).map(Number));
   }

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -1,6 +1,7 @@
 define([
-  '../point'
-], function(Point) {
+  '../point',
+  '../tools'
+], function(Point, tools) {
   'use strict';
 
   var cos = Math.cos, sin = Math.sin;
@@ -19,7 +20,7 @@ define([
    * @param {number} ty Vertical/y translation
    */
   function Matrix(a, b, c, d, tx, ty) {
-    if (a instanceof Array) {
+    if (tools.isArray(a)) {
       return Matrix.apply(this, a);
     }
 

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -11,7 +11,7 @@ define([
    * @constructor
    * @name Matrix
    *
-   * @param {number|string} a Horizontal/x scale or matrix string "matrix(0,1,0,0,1,1)"
+   * @param {number|array} a Horizontal/x scale or array of a, b, c, d, tx, ty
    * @param {number} b Vertical/y skew
    * @param {number} c Horizontal/x skew
    * @param {number} d Vertical/y scale
@@ -19,9 +19,8 @@ define([
    * @param {number} ty Vertical/y translation
    */
   function Matrix(a, b, c, d, tx, ty) {
-    if ('string' === typeof a && a.match(/^matrix/)) {
-      var args = a.match(/[^a-z(),]+/g).map(function(i) { return +i });
-      return Matrix.apply(this, args);
+    if (a instanceof Array) {
+      return Matrix.apply(this, a);
     }
 
     this.a = a != null ? a : 1;

--- a/test/matrix-spec.js
+++ b/test/matrix-spec.js
@@ -25,7 +25,7 @@ define([
       expect(matrix.ty).toBe(0);
     });
 
-    it('should set a, b, c, d, tx, ty defaults for undefineds', function(){
+    it('should set a, b, c, d, tx, ty defaults for nulls', function(){
       var matrix = new Matrix(null, null, null, null, null, null);
       expect(matrix.a).toBe(1);
       expect(matrix.b).toBe(0);
@@ -33,6 +33,16 @@ define([
       expect(matrix.d).toBe(1);
       expect(matrix.tx).toBe(0);
       expect(matrix.ty).toBe(0);
+    });
+
+    it('should set a, b, c, d, tx, ty for a matrix string', function(){
+      var matrix = new Matrix('matrix(4,2,1,6,5,4)');
+      expect(matrix.a).toBe(4);
+      expect(matrix.b).toBe(2);
+      expect(matrix.c).toBe(1);
+      expect(matrix.d).toBe(6);
+      expect(matrix.tx).toBe(5);
+      expect(matrix.ty).toBe(4);
     });
 
   });

--- a/test/matrix-spec.js
+++ b/test/matrix-spec.js
@@ -35,8 +35,8 @@ define([
       expect(matrix.ty).toBe(0);
     });
 
-    it('should set a, b, c, d, tx, ty for a matrix string', function(){
-      var matrix = new Matrix('matrix(4,2,1,6,5,4)');
+    it('should set a, b, c, d, tx, ty for an array', function(){
+      var matrix = new Matrix([4,2,1,6,5,4]);
       expect(matrix.a).toBe(4);
       expect(matrix.b).toBe(2);
       expect(matrix.c).toBe(1);
@@ -46,5 +46,5 @@ define([
     });
 
   });
-  
+
 });

--- a/test/matrix-spec.js
+++ b/test/matrix-spec.js
@@ -47,4 +47,33 @@ define([
 
   });
 
+  describe('Matrix.fromString', function () {
+
+    it('should return a new Matrix with a, b, c, d, tx, ty from `matrix(a,b,c,d,e,f)`', function(){
+      var matrix = Matrix.fromString('4,2,1,6,5,4');
+      expect(matrix.a).toBe(4);
+      expect(matrix.b).toBe(2);
+      expect(matrix.c).toBe(1);
+      expect(matrix.d).toBe(6);
+      expect(matrix.tx).toBe(5);
+      expect(matrix.ty).toBe(4);
+    });
+
+    it('should return a new Matrix with a, b, c, d, tx, ty for a string of `"a, b, c, d, tx, ty"`', function(){
+      var matrix = Matrix.fromString('matrix(4,2,1,6,5,4)');
+      expect(matrix.a).toBe(4);
+      expect(matrix.b).toBe(2);
+      expect(matrix.c).toBe(1);
+      expect(matrix.d).toBe(6);
+      expect(matrix.tx).toBe(5);
+      expect(matrix.ty).toBe(4);
+    });
+
+    it('should return an instance of a Matrix', function(){
+      var matrix = Matrix.fromString('matrix(4,2,1,6,5,4)');
+      expect(matrix).toBeInstanceOf(Matrix);
+    })
+
+  })
+  
 });


### PR DESCRIPTION
I am reading attributes from an SVG string and passing it to the Bonsai runner.

With the relevant attribute for a Matrix from an svg node being `transform='matrix(0,1,0,0,1,1)'` I thought it may be useful to others to have this alternative method signature.

```
var matrix = new Matrix('matrix(0,1,0,0,1,1)'
```

Thoughts?
