### PR TITLE
Signature changes for `DisplayList#add()`

### DIFF
--- a/src/runner/display_list.js
+++ b/src/runner/display_list.js
@@ -66,8 +66,8 @@ define([
 
       var children = this.children;
       var numExistingChildren = children.length;
-      insertAt = arguments.length > 1 ?
-        min(insertAt >>> 0, numExistingChildren) : numExistingChildren;
+      insertAt = insertAt === void 0 ?
+        numExistingChildren : min(insertAt >>> 0, numExistingChildren);
 
       if (isChildArray) {
         children.splice.apply(children, [insertAt, 0].concat(child));
@@ -198,11 +198,7 @@ define([
      * @return {this}
      */
     addChild: function(child, index) {
-      if (arguments.length === 1) {
-        this.displayList.add(child);
-      } else {
-        this.displayList.add(child, index);
-      }
+      this.displayList.add(child, index);
       return this;
     },
     /**

--- a/test/common/displaylist-owner.js
+++ b/test/common/displaylist-owner.js
@@ -49,7 +49,7 @@ define([
       it('forwards a single argument to this.displayList.add', function() {
         var child = mock.createDisplayObject();
         owner.addChild(child);
-        expect(displayList.add).toHaveBeenCalledWith(child);
+        expect(displayList.add).toHaveBeenCalledWith(child, void 0);
       });
 
       it('forwards both arguments to this.displayList.add', function() {

--- a/test/display_list-spec.js
+++ b/test/display_list-spec.js
@@ -287,6 +287,19 @@ define([
           expect(newChild.next).toBe(existingChild);
         });
 
+        it('should treat an undefined (but given) index parameter as if only one argument was passed and append the child', function() {
+          var displayList = createDisplayList();
+          displayList.add([
+            createArbitraryDisplayObject(),
+            createArbitraryDisplayObject(),
+            createArbitraryDisplayObject()]
+          );
+
+          var newChild = createArbitraryDisplayObject();
+          displayList.add(newChild, void 0);
+          expect(displayList.children.indexOf(newChild)).toBe(3);
+        });
+
         it('should avoid adding the owner of a display list to the display list', function() {
           var owner = createArbitraryDisplayObject();
           var displayList = createDisplayList(owner);


### PR DESCRIPTION
Makes `DisplayList#add(child, undefined)` equivalent to `DisplayList#add(child)`.
At the moment, `DisplayList#add(child, undefined)` works as `DisplayList#add(child, 0)`, which requires argument checking in many methods that use `add()`.
