### PR TITLE
Print full test name

### DIFF
--- a/lib/jasmine-console/console-runner.js
+++ b/lib/jasmine-console/console-runner.js
@@ -91,7 +91,7 @@
     var results = suite.results();
     var failed = results.totalCount - results.passedCount;
     var color = (failed > 0)? "red" : "green";
-    this.log(suite.description + ": " + results.passedCount + " of " + results.totalCount + " passed.", color);
+    this.log(suite.getFullName() + ": " + results.passedCount + " of " + results.totalCount + " passed.", color);
   };
 
   proto.log = function(str, color) {


### PR DESCRIPTION
Grabbed an open pull request for `phantom-jasmine` https://github.com/jcarver989/phantom-jasmine/pull/9/files#L0R94 to get full names printed to the console.

Example:

```
Svg Submodule of SvgRenderer submodule: 1 of 1 passed.
Svg Submodule of SvgRenderer the constructor: 2 of 2 passed.
Svg Submodule of SvgRenderer has a `attr` method basicAttributeMap: 1 of 1 passed.
Svg Submodule of SvgRenderer has a `attr` method has some special handlers for certain attributes has a special handler for `strokeWidth`: 2 of 2 passed.
Svg Submodule of SvgRenderer has a `attr` method has some special handlers for certain attributes: 2 of 2 passed.
Svg Submodule of SvgRenderer has a `attr` method: 3 of 3 passed.
```

As opposed to:

```
submodule: 1 of 1 passed.
the constructor: 2 of 2 passed.
has a `attr` method basicAttributeMap: 1 of 1 passed.
has a `attr` method has some special handlers for certain attributes has a special handler for `strokeWidth`: 2 of 2 passed.
has a `attr` method has some special handlers for certain attributes: 2 of 2 passed.
has a `attr` method: 3 of 3 passed.
```
