### PR TITLE
Expose EventEmitter and tools

### DIFF
--- a/src/bootstrapper/player.js
+++ b/src/bootstrapper/player.js
@@ -1,18 +1,21 @@
 define([
+  '../event_emitter',
   '../renderer/renderer_controller',
   '../asset/asset_controller',
   '../tools',
   '../uri',
   '../version'
 ],
-function(RendererController, AssetController, tools, URI, version) {
+function(EventEmitter, RendererController, AssetController, tools, URI, version) {
   'use strict';
 
   var player = {
     version: version,
 
     AssetController: AssetController,
+    EventEmitter: EventEmitter,
     RendererController: RendererController,
+    tools: tools,
 
     defaultRunnerOptions: {},
     _addDefaultRunnerOptions: function(options) {

--- a/src/runner/environment.js
+++ b/src/runner/environment.js
@@ -82,6 +82,7 @@ define([
       Arc: Arc,
 
       DisplayList: displayList.DisplayList,
+      EventEmitter: EventEmitter,
 
       Point: Point,
       color: color,

--- a/test/player-spec.js
+++ b/test/player-spec.js
@@ -1,7 +1,9 @@
 define([
   'bonsai/bootstrapper/player',
+  'bonsai/event_emitter',
+  'bonsai/tools',
   'bonsai/uri'
-], function (player, URI) {
+], function (player, EventEmitter, tools, URI) {
   'use strict';
 
   var MockAssetControllerConstructor,
@@ -56,6 +58,14 @@ define([
 
     it('has a defaultRunnerOptions property which is an object', function() {
       expect(player.defaultRunnerOptions).toBeInstanceOf(Object);
+    });
+
+    it('exposes the EventEmiiter', function() {
+      expect(player.EventEmitter).toBe(EventEmitter);
+    });
+
+    it('exposes tools', function() {
+      expect(player.tools).toBe(tools);
     });
 
     describe('.baseUrl()', function () {


### PR DESCRIPTION
Use case is to create your own RunnerContext. An example can be found here: https://github.com/uxebu/bonsai-server/blob/master/example/client.html#L15-34
