### PR TITLE
stroke-dasharray attribute on paths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 v0.4.3
 -------------------
-
+* Add support for `strokeDash` and `strokeDashOffset` attributes on all Paths.
 
 v0.4.2 / 2013-01-14
 -------------------

--- a/example/library/movies/movie_list.js
+++ b/example/library/movies/movie_list.js
@@ -141,6 +141,7 @@ movieList = {
     'shape-getPointAtLength.js',
     'shape-center-of-arc.js',
     'shape-fill-rule.js',
+    'shape-dashedstrokes.js',
     'overlapping-paths.js',
     'bounding-box.js'
   ],

--- a/example/library/movies/shape-dashedstrokes.js
+++ b/example/library/movies/shape-dashedstrokes.js
@@ -1,0 +1,21 @@
+var rect = new Rect(50, 50, 100, 100).addTo(stage);
+rect.attr({
+  strokeWidth: 1,
+  strokeDashArray: '5,4',
+  strokeOffset: '5',
+  strokeColor: 'black',
+  fillColor: 'yellow'
+});
+
+var i = 0;
+var offset = false;
+setInterval(function () {
+  i++;
+
+  rect.attr('strokeOffset', i);
+
+  if (i === 9) i = 0;
+}, 100);
+
+}, 1000);
+

--- a/example/library/movies/shape-dashedstrokes.js
+++ b/example/library/movies/shape-dashedstrokes.js
@@ -28,3 +28,25 @@ star.animate(new KeyframeAnimation('4s', {
 }, { repeat: Infinity }));
 
 
+// Base morph from animation-morph.js
+var a = Path.star(100, 100, 100, 5).attr({
+  x: 400, y: 400,
+  fillColor: 'red',
+  opacity: 0.5,
+  strokeDash: [20, 5, 10, 5],
+  strokeColor: 'blue',
+  strokeWidth: 5,
+  rotation: Math.PI
+});
+var b = new Star(250, 250, 200, 10).attr({
+  fillColor: 'blue',
+  strokeDash: [10, 10, 10, 10],
+  strokeColor: 'blue',
+  strokeWidth: 5,
+  rotation: 0
+});
+
+a.addTo(stage, 0);
+
+a.morphTo(b, '3s');
+

--- a/example/library/movies/shape-dashedstrokes.js
+++ b/example/library/movies/shape-dashedstrokes.js
@@ -1,8 +1,8 @@
 var rect = new Rect(50, 50, 100, 100).addTo(stage);
 rect.attr({
   strokeWidth: 1,
-  strokeDashArray: '5,4',
-  strokeOffset: '5',
+  strokeDash: [5, 4],
+  strokeDashOffset: '5',
   strokeColor: 'black',
   fillColor: 'yellow'
 });
@@ -12,10 +12,23 @@ var offset = false;
 setInterval(function () {
   i++;
 
-  rect.attr('strokeOffset', i);
+  rect.attr('strokeDashOffset', i);
 
   if (i === 9) i = 0;
 }, 100);
 
-}, 1000);
+var star = new Star(100, 97, 20, 5, 3).addTo(stage);
+star.attr({
+  strokeWidth: 1,
+  strokeDash: [10, 5, 10, 3],
+  strokeDashOffset: 5,
+  strokeColor: 'orange',
+  fillColor: 'white'
+});
+
+
+star.animate('1s', {
+  strokeDashOffset: 28
+}, { repeat: Infinity });
+
 

--- a/example/library/movies/shape-dashedstrokes.js
+++ b/example/library/movies/shape-dashedstrokes.js
@@ -7,28 +7,24 @@ rect.attr({
   fillColor: 'yellow'
 });
 
-var i = 0;
-var offset = false;
-setInterval(function () {
-  i++;
+rect.animate('0.5s', {
+  strokeDashOffset: 14,
+}, { repeat: Infinity });
 
-  rect.attr('strokeDashOffset', i);
-
-  if (i === 9) i = 0;
-}, 100);
 
 var star = new Star(100, 97, 20, 5, 3).addTo(stage);
 star.attr({
   strokeWidth: 1,
   strokeDash: [10, 5, 10, 3],
-  strokeDashOffset: 5,
   strokeColor: 'orange',
   fillColor: 'white'
 });
 
-
-star.animate('1s', {
-  strokeDashOffset: 28
-}, { repeat: Infinity });
+// animations of stroke dashes with a different length works, too!
+star.animate(new KeyframeAnimation('4s', {
+  '0%': { strokeDash: [ 10, 5, 10, 3 ]},
+  '50%': { strokeDash: [ 20, 10 ]},
+  '100%': { strokeDash: [ 10, 5, 10, 3 ]}
+}, { repeat: Infinity }));
 
 

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -47,6 +47,7 @@ define([
     opacity: 'opacity',
     fillOpacity: 'fill-opacity',
     strokeOpacity: 'stroke-opacity',
+    strokeDashArray: 'stroke-dasharray',
     fontSize: 'font-size',
     fontWeight: 'font-weight',
     fontStyle: 'font-style',

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -65,6 +65,7 @@ define([
     fillOpacity: ['fill-opacity', '1'],
     strokeOpacity: ['stroke-opacity', '1'],
     strokeDashArray: ['stroke-dasharray'],
+    strokeOffset: ['stroke-dashoffset'],
     fontSize: ['font-size'],
     fontWeight: ['font-weight'],
     fontStyle: ['font-style'],
@@ -562,6 +563,11 @@ define([
       if ('strokeGradient' in attr) {
         this.applyStrokeGradient(element, attr.strokeGradient, '', attr.strokeWidth);
       }
+
+      if ('strokeDashArray' in attr) {
+        this.applyStrokeDashArray(element, attr.strokeDashArray, attr.strokeOffset || 0);
+      }
+
     }
   };
 
@@ -1018,6 +1024,16 @@ define([
     } else if (aColor === null) {
       element.removeAttribute('stroke');
       element.removeAttribute('data-stroke');
+    }
+  };
+
+  proto.applyStrokeDashArray = function(element, strokeDashArray, strokeOffset) {
+    if (strokeDashArray) {
+      element.setAttribute('stroke-dasharray', strokeDashArray);
+      element.setAttribute('stroke-dashoffset', strokeOffset);
+    } else {
+      element.removeAttribute('stroke-dasharray');
+      element.removeAttribute('stroke-dashoffset');
     }
   };
 

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -565,7 +565,7 @@ define([
       }
 
       if ('strokeDash' in attr) {
-        this.applyStrokeDashArray(element, attr.strokeDash.join(''), attr.strokeDashOffset);
+        this.applyStrokeDashArray(element, attr.strokeDash, attr.strokeDashOffset);
       }
 
     }

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -64,8 +64,8 @@ define([
     opacity: ['opacity', '1'],
     fillOpacity: ['fill-opacity', '1'],
     strokeOpacity: ['stroke-opacity', '1'],
-    strokeDashArray: ['stroke-dasharray'],
-    strokeOffset: ['stroke-dashoffset'],
+    strokeDash: ['stroke-dasharray'],
+    strokeDashOffset: ['stroke-dashoffset'],
     fontSize: ['font-size'],
     fontWeight: ['font-weight'],
     fontStyle: ['font-style'],
@@ -564,8 +564,8 @@ define([
         this.applyStrokeGradient(element, attr.strokeGradient, '', attr.strokeWidth);
       }
 
-      if ('strokeDashArray' in attr) {
-        this.applyStrokeDashArray(element, attr.strokeDashArray, attr.strokeOffset || 0);
+      if ('strokeDash' in attr) {
+        this.applyStrokeDashArray(element, attr.strokeDash.join(''), attr.strokeDashOffset);
       }
 
     }

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -1030,7 +1030,7 @@ define([
   proto.applyStrokeDashArray = function(element, strokeDashArray, strokeOffset) {
     if (strokeDashArray) {
       element.setAttribute('stroke-dasharray', strokeDashArray);
-      element.setAttribute('stroke-dashoffset', strokeOffset);
+      element.setAttribute('stroke-dashoffset', strokeOffset || 0);
     } else {
       element.removeAttribute('stroke-dasharray');
       element.removeAttribute('stroke-dashoffset');

--- a/src/runner/animation/properties_tween.js
+++ b/src/runner/animation/properties_tween.js
@@ -6,11 +6,13 @@ define([
   './translators/filter',
   './translators/segment',
   './translators/matrix',
-  './translators/corner_radius'
+  './translators/corner_radius',
+  './translators/stroke_dash'
 ], function(
   tools, PropertyTween,
   colorTranslators, gradientTranslators, filterTranslators,
-  segmentTranslators, matrixTranslators, cornerRadiusTranslators
+  segmentTranslators, matrixTranslators, cornerRadiusTranslators,
+  strokeDashTranslators
 ) {
 
   var mixin = tools.mixin;
@@ -28,6 +30,7 @@ define([
   mixin(translators, segmentTranslators);
   mixin(translators, matrixTranslators);
   mixin(translators, cornerRadiusTranslators);
+  mixin(translators, strokeDashTranslators);
 
   /**
    * Constructs an instance of PropertiesTween which takes care of tweening

--- a/src/runner/animation/translators/stroke_dash.js
+++ b/src/runner/animation/translators/stroke_dash.js
@@ -28,9 +28,6 @@ define(function() {
           if (isNaN(strokeDash)) {
             strokeDashes[i] = 0;
           }
-          else {
-            strokeDashes[i] = strokeDash;
-          }
         }
 
         return strokeDashes;

--- a/src/runner/animation/translators/stroke_dash.js
+++ b/src/runner/animation/translators/stroke_dash.js
@@ -1,0 +1,41 @@
+define(function() {
+  'use strict';
+
+  /**
+   * Animation translations for shape segments
+   * @ignore
+   */
+
+  return {
+    strokeDash: {
+      toNumeric: function(strokeDashes, isEndValues) {
+        var numbers = [];
+        if (!isEndValues) {
+          this.strokeDash = strokeDashes;
+        }
+        for (var i = 0, l = strokeDashes.length; i < l; ++i) {
+          var strokeDash = strokeDashes[i];
+          if (!isNaN(strokeDash)) {
+            numbers.push(strokeDash);
+          }
+        }
+        return numbers;
+      },
+      toAttr: function(numbers) {
+        var strokeDashes = numbers;
+        for (var i = 0, l = strokeDashes.length; i < l; i++) {
+          var strokeDash = strokeDashes[i];
+          if (isNaN(strokeDash)) {
+            strokeDashes[i] = 0;
+          }
+          else {
+            strokeDashes[i] = strokeDash;
+          }
+        }
+
+        return strokeDashes;
+      }
+    }
+  };
+});
+

--- a/src/runner/animation/translators/stroke_dash.js
+++ b/src/runner/animation/translators/stroke_dash.js
@@ -9,23 +9,18 @@ define(function() {
   return {
     strokeDash: {
       toNumeric: function(strokeDashes, isEndValues) {
-        var numbers = [];
-        if (!isEndValues) {
-          this.strokeDash = strokeDashes;
-        }
-        for (var i = 0, l = strokeDashes.length; i < l; ++i) {
-          var strokeDash = strokeDashes[i];
-          if (!isNaN(strokeDash)) {
-            numbers.push(strokeDash);
+        var numbers = [], i = 0, len = strokeDashes.length;
+        for (i; i < len; ++i) {
+          if (!isNaN(strokeDashes[i])) {
+            numbers.push(strokeDashes[i]);
           }
         }
         return numbers;
       },
-      toAttr: function(numbers) {
-        var strokeDashes = numbers;
-        for (var i = 0, l = strokeDashes.length; i < l; i++) {
-          var strokeDash = strokeDashes[i];
-          if (isNaN(strokeDash)) {
+      toAttr: function(strokeDashes) {
+        var i = 0, len = strokeDashes.length;
+        for (i; i < len; ++i) {
+          if (isNaN(strokeDashes[i])) {
             strokeDashes[i] = 0;
           }
         }

--- a/src/runner/path/path.js
+++ b/src/runner/path/path.js
@@ -101,24 +101,12 @@ define([
     this._strokeColor = parseColor(color, this._strokeColor);
   }
 
-  var getStrokeDashArray = getter('_strokeDashArray');
-  function setStrokeDashArray(dashArray) {
-    if (dashArray) {
-      if (dashArray.join) {
-        dashArray = dashArray.join(', ');
-      }
-      this._strokeDashArray = dashArray;
+  var getStrokeDash = getter('_strokeDash');
+  function setStrokeDash(dashArray) {
+    if (tools.isArray(dashArray)) {
+      this._strokeDash = dashArray;
     } else {
-      this._strokeDashArray = null;
-    }
-  }
-
-  var getStrokeOffset = getter('_strokeDashOffset');
-  function setStrokeOffset(strokeOffset) {
-    if (strokeOffset) {
-      this._strokeOffset = strokeOffset;
-    } else {
-      this._strokeOffset = null;
+      this._strokeDash = null;
     }
   }
 
@@ -201,7 +189,8 @@ define([
    * @property {String} __supportedAttributes__.join The shape to be used at the corners of paths. Can be one of 'miter', 'round', 'bevel'. Default: 'miter'
    * @property {String} __supportedAttributes__.strokeColor The line color. Default: transparent
    * @property {gradient.LinearGradient|gradient.RadialGradient} __supportedAttributes__.strokeGradient The line gradient. Default: nothing
-   * @property {String} __supportedAttributes__.strokeDashArray The stroke dasharray. Default: nothing
+   * @property {Array} __supportedAttributes__.strokeDash The stroke dasharray. Default: nothing
+   * @property {Number} __supportedAttributes__.strokeDashOffset The stroke dasharray. Default: 0
    * @property {Number} __supportedAttributes__.strokeWidth The line width. Default: 0
    * @property {Number} __supportedAttributes__.miterLimit The miter limit of the stroke. Default: 4
    *
@@ -232,10 +221,9 @@ define([
       strokeColor: accessor(getStrokeColor, setStrokeColor, true),
       _strokeGradient: data(undefined, true),
       strokeGradient: accessor(getStrokeGradient, setStrokeGradient, true),
-      _strokeDashArray: data(null, true),
-      strokeDashArray: accessor(getStrokeDashArray, setStrokeDashArray, true),
-      _strokeOffset: data(null, true),
-      strokeOffset: accessor(getStrokeOffset, setStrokeOffset, true),
+      _strokeDash: data(null, true),
+      strokeDash: accessor(getStrokeDash, setStrokeDash, true),
+      strokeDashOffset: data(0, true, true),
 
       strokeWidth: data(0, true, true),
       _miterLimit: data(4, true),
@@ -257,8 +245,8 @@ define([
     rendererAttributes.join = '_join';
     rendererAttributes.strokeWidth = 'strokeWidth';
     rendererAttributes.miterLimit = '_miterLimit';
-    rendererAttributes.strokeDashArray = 'strokeDashArray';
-    rendererAttributes.strokeOffset = '_strokeOffset';
+    rendererAttributes.strokeDash = '_strokeDash';
+    rendererAttributes.strokeDashOffset = 'strokeDashOffset';
 
     this.morphableAttributes = {
       x: 1,
@@ -269,9 +257,8 @@ define([
       strokeWidth: 1,
       fillOpacity: 1,
       strokeOpacity: 1,
-      strokeDashArray: 1,
-      strokeOffset: 1,
-      stroke: 1,
+      strokeDash: 1,
+      strokeDashOffset: 1,
       opacity: 1,
       fillGradient: 1,
       scale: 1,

--- a/src/runner/path/path.js
+++ b/src/runner/path/path.js
@@ -101,6 +101,19 @@ define([
     this._strokeColor = parseColor(color, this._strokeColor);
   }
 
+  var getStrokeDashArray = getter('_strokeDashArray');
+
+  function setStrokeDashArray(dashArray) {
+    if (dashArray) {
+      if (dashArray.join) {
+        dashArray = dashArray.join(', ');
+      }
+      this._strokeDashArray = dashArray;
+    } else {
+      this._strokeDashArray = null;
+    }
+  }
+
   function getStrokeGradient() {
     return this._strokeGradient;
   }
@@ -180,6 +193,7 @@ define([
    * @property {String} __supportedAttributes__.join The shape to be used at the corners of paths. Can be one of 'miter', 'round', 'bevel'. Default: 'miter'
    * @property {String} __supportedAttributes__.strokeColor The line color. Default: transparent
    * @property {gradient.LinearGradient|gradient.RadialGradient} __supportedAttributes__.strokeGradient The line gradient. Default: nothing
+   * @property {String} __supportedAttributes__.strokeDashArray The stroke dasharray. Default: nothing
    * @property {Number} __supportedAttributes__.strokeWidth The line width. Default: 0
    * @property {Number} __supportedAttributes__.miterLimit The miter limit of the stroke. Default: 4
    *
@@ -210,6 +224,9 @@ define([
       strokeColor: accessor(getStrokeColor, setStrokeColor, true),
       _strokeGradient: data(undefined, true),
       strokeGradient: accessor(getStrokeGradient, setStrokeGradient, true),
+      _strokeDashArray: data(null, true),
+      strokeDashArray: accessor(getStrokeDashArray, setStrokeDashArray, true),
+
       strokeWidth: data(0, true, true),
       _miterLimit: data(4, true),
       miterLimit: accessor(getMiterLimit, setMiterLimit, true),

--- a/src/runner/path/path.js
+++ b/src/runner/path/path.js
@@ -102,7 +102,6 @@ define([
   }
 
   var getStrokeDashArray = getter('_strokeDashArray');
-
   function setStrokeDashArray(dashArray) {
     if (dashArray) {
       if (dashArray.join) {
@@ -111,6 +110,15 @@ define([
       this._strokeDashArray = dashArray;
     } else {
       this._strokeDashArray = null;
+    }
+  }
+
+  var getStrokeOffset = getter('_strokeDashOffset');
+  function setStrokeOffset(strokeOffset) {
+    if (strokeOffset) {
+      this._strokeOffset = strokeOffset;
+    } else {
+      this._strokeOffset = null;
     }
   }
 
@@ -226,6 +234,8 @@ define([
       strokeGradient: accessor(getStrokeGradient, setStrokeGradient, true),
       _strokeDashArray: data(null, true),
       strokeDashArray: accessor(getStrokeDashArray, setStrokeDashArray, true),
+      _strokeOffset: data(null, true),
+      strokeOffset: accessor(getStrokeOffset, setStrokeOffset, true),
 
       strokeWidth: data(0, true, true),
       _miterLimit: data(4, true),
@@ -247,6 +257,8 @@ define([
     rendererAttributes.join = '_join';
     rendererAttributes.strokeWidth = 'strokeWidth';
     rendererAttributes.miterLimit = '_miterLimit';
+    rendererAttributes.strokeDashArray = 'strokeDashArray';
+    rendererAttributes.strokeOffset = '_strokeOffset';
 
     this.morphableAttributes = {
       x: 1,
@@ -257,6 +269,9 @@ define([
       strokeWidth: 1,
       fillOpacity: 1,
       strokeOpacity: 1,
+      strokeDashArray: 1,
+      strokeOffset: 1,
+      stroke: 1,
       opacity: 1,
       fillGradient: 1,
       scale: 1,

--- a/test/path/path-spec.js
+++ b/test/path/path-spec.js
@@ -332,6 +332,11 @@ define([
           var s = new Path().attr('strokeDash', [5, 5, 3, 5]);
           expect(s.attr('strokeDash')).toEqual([5, 5, 3, 5]);
         });
+
+        it('should return null if given a non-array', function(){
+          var s = new Path().attr('strokeDash', '');
+          expect(s.attr('strokeDash')).toEqual(null);
+        });
       });
 
       describe('Sets & Gets strokeDashOffset', function(){
@@ -343,6 +348,7 @@ define([
           var s = new Path().attr('strokeDashOffset', 5);
           expect(s.attr('strokeDashOffset')).toEqual(5);
         });
+
       });
 
       it('Sets & Gets opacity', function(){

--- a/test/path/path-spec.js
+++ b/test/path/path-spec.js
@@ -323,13 +323,30 @@ define([
         expect(s.attr('strokeColor')).toBe(0xff0000ff);
       });
 
-      it('Sets & Gets strokeDashArray', function(){
-        var s = new Path();
-        expect(s.attr('strokeDashArray')).toBe(null);
-        s.attr('strokeDashArray', '5, 5');
-        expect(s.attr('strokeDashArray')).toBe('5, 5');
-        s.attr('strokeDashArray', [5, 5]);
-        expect(s.attr('strokeDashArray')).toBe('5, 5');
+      describe('Sets & Gets strokeDash', function(){
+        it('returns null be default', function(){
+          expect(new Path().attr('strokeDash')).toBe(null);
+        });
+
+        it('should be settable/gettable', function(){
+          var s = new Path().attr('strokeDash', [5, 5, 3, 5]);
+          expect(s.attr('strokeDash')).toEqual([5, 5, 3, 5]);
+          s.attr('strokeDash', '');
+          expect(s.attr('strokeDash')).toBe(null);
+        });
+      });
+
+      describe('Sets & Gets strokeDashOffset', function(){
+        it('returns 0 be default', function(){
+          expect(new Path().attr('strokeDashOffset')).toBe(0);
+        });
+
+        it('should be settable/gettable', function(){
+          var s = new Path().attr('strokeDashOffset', 5);
+          expect(s.attr('strokeDashOffset')).toEqual(5);
+          s.attr('strokeDashOffset', 0);
+          expect(s.attr('strokeDashOffset')).toBe(0);
+        });
       });
 
       it('Sets & Gets opacity', function(){

--- a/test/path/path-spec.js
+++ b/test/path/path-spec.js
@@ -331,8 +331,6 @@ define([
         it('should be settable/gettable', function(){
           var s = new Path().attr('strokeDash', [5, 5, 3, 5]);
           expect(s.attr('strokeDash')).toEqual([5, 5, 3, 5]);
-          s.attr('strokeDash', '');
-          expect(s.attr('strokeDash')).toBe(null);
         });
       });
 
@@ -344,8 +342,6 @@ define([
         it('should be settable/gettable', function(){
           var s = new Path().attr('strokeDashOffset', 5);
           expect(s.attr('strokeDashOffset')).toEqual(5);
-          s.attr('strokeDashOffset', 0);
-          expect(s.attr('strokeDashOffset')).toBe(0);
         });
       });
 

--- a/test/path/path-spec.js
+++ b/test/path/path-spec.js
@@ -323,6 +323,15 @@ define([
         expect(s.attr('strokeColor')).toBe(0xff0000ff);
       });
 
+      it('Sets & Gets strokeDashArray', function(){
+        var s = new Path();
+        expect(s.attr('strokeDashArray')).toBe(null);
+        s.attr('strokeDashArray', '5, 5');
+        expect(s.attr('strokeDashArray')).toBe('5, 5');
+        s.attr('strokeDashArray', [5, 5]);
+        expect(s.attr('strokeDashArray')).toBe('5, 5');
+      });
+
       it('Sets & Gets opacity', function(){
         var s = new Path();
         expect(s.attr('opacity')).toBe(1);


### PR DESCRIPTION
I’ve started work on #134 to implement the stroke-dasharray attribute.
(docs: https://developer.mozilla.org/en-US/docs/SVG/Attribute/stroke-dasharray)

I believe everything should be set on the runner side of things, but I’m looking for some pointers on where to go in the `renderer/svg/` files to implement the receiving side of things and what the easiest way to visually and jasmine-y test it.
