### PR TITLE
Change typo in matrix docs

### DIFF
--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -72,7 +72,7 @@ define([
      * Applies parameters for scaling, rotation, and translation.
      *
      * Using the createBox() method lets you obtain the same matrix as you
-     * would if you applied the identify(), rotate(), scale(), and translate()
+     * would if you applied the identity(), rotate(), scale(), and translate()
      * methods in succession.
      *
      * @param {number} scaleX The horizontal scale
@@ -84,7 +84,7 @@ define([
      */
     createBox: function(scaleX, scaleY, rotation, tx, ty) {
       return this.
-        identify().
+        identity().
         rotate(rotation).
         scale(scaleX, scaleY).
         translate(tx, ty);
@@ -134,12 +134,12 @@ define([
     /**
      * Sets each matrix property to a value that causes a null transformation.
      *
-     * An object transformed by applying an identify matrix will be identical
+     * An object transformed by applying an identity matrix will be identical
      * to the original.
      *
      * @returns {Matrix} The instance
      */
-    identify: function() {
+    identity: function() {
       this.a = this.d = 1;
       this.b = this.c = this.tx = this.ty = 0;
       return this;

--- a/src/runner/matrix.js
+++ b/src/runner/matrix.js
@@ -72,7 +72,7 @@ define([
      * Applies parameters for scaling, rotation, and translation.
      *
      * Using the createBox() method lets you obtain the same matrix as you
-     * would if you applied the identity(), rotate(), scale(), and translate()
+     * would if you applied the identify(), rotate(), scale(), and translate()
      * methods in succession.
      *
      * @param {number} scaleX The horizontal scale
@@ -134,7 +134,7 @@ define([
     /**
      * Sets each matrix property to a value that causes a null transformation.
      *
-     * An object transformed by applying an identity matrix will be identical
+     * An object transformed by applying an identify matrix will be identical
      * to the original.
      *
      * @returns {Matrix} The instance

--- a/test/display_object-spec.js
+++ b/test/display_object-spec.js
@@ -137,7 +137,7 @@ define([
         d.attr('rotation', rotation);
         m = d.attr('matrix');
 
-        m2 = m.clone().identify().rotate(rotation);
+        m2 = m.clone().identity().rotate(rotation);
         p = m2.transformPoint(origin);
 
         expect(m.a).toBe(m2.a);
@@ -169,7 +169,7 @@ define([
         }
 
         m = d.attr('matrix');
-        m2 = m.clone().identify().rotate(rotation).scale(scale, scale);
+        m2 = m.clone().identity().rotate(rotation).scale(scale, scale);
         ['a', 'b', 'c', 'd', 'tx', 'ty'].forEach(function(p) {
           expect(m[p]).toBeCloseTo(m2[p], 10);
         });

--- a/test/matrix-qc.js
+++ b/test/matrix-qc.js
@@ -116,10 +116,10 @@ define([
   );
 
   qc.declare(
-    '`identify()` should reset each matrix to identity',
+    '`identity()` should reset each matrix to identity',
     [matrixGenerator(10)],
     function(testCase, m) {
-      var matrix = toMatrix(m).identify();
+      var matrix = toMatrix(m).identity();
       testCase.assert(equals(matrix, IDENTITY_MATRIX));
     }
   );
@@ -194,7 +194,7 @@ define([
   );
 
   qc.declare(
-    '`createBox()` should work like calling identify(), rotation(), scale() ' +
+    '`createBox()` should work like calling identity(), rotation(), scale() ' +
     'and translate() in succession',
     [
       scaleGenerator,
@@ -206,7 +206,7 @@ define([
     function(testCase, scaleX, scaleY, rotation, tx, ty) {
       var matrix = new Matrix().createBox(scaleX, scaleY, rotation, tx, ty);
       var refMatrix = new Matrix().
-        identify().
+        identity().
         rotate(rotation).
         scale(scaleX, scaleY).
         translate(tx, ty);


### PR DESCRIPTION
Change docs text `identity` to the method name `identify`
