### PR TITLE
Defer sendmessage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ v0.4.2
    DisplayObject
  * Added an destroy event for DisplayObjects, which is fired on a displayobject when
    destroy is called on it.
+ * Sending of user messages to runner contexts is deferred until context startup
 
 v0.4.1 / 2012-10-26
 -------------------

--- a/src/renderer/renderer_controller.js
+++ b/src/renderer/renderer_controller.js
@@ -11,6 +11,22 @@ define([
 function(tools, EventEmitter, URI) {
   'use strict';
 
+  function onContextLoad(rendererController) {
+    var pendingMessages = rendererController._pendingMessages;
+
+    // set to null first, so that further calls to sendMessage are not queued
+    rendererController._pendingMessages = null;
+
+    // send all queued messages again
+    var sendMessage = rendererController.sendMessage;
+    tools.forEach(pendingMessages, function(messageArguments) {
+      sendMessage.apply(rendererController, messageArguments);
+    });
+
+    // emit load event
+    rendererController.emit('load');
+  }
+
   var hitch = tools.hitch;
 
   /**
@@ -30,6 +46,7 @@ function(tools, EventEmitter, URI) {
     this.runnerContext = runnerContext;
     this._movieOptions = this._cleanOptions(options);
     this.baseUrl = URI.parse(options.baseUrl);
+    this._pendingMessages = [];
 
     runnerContext.on('message', this, this.handleEvent);
 
@@ -79,7 +96,7 @@ function(tools, EventEmitter, URI) {
               if (options.code) {
                 runnerContext.run(options.code);
               }
-              rendererController.emit('load');
+              onContextLoad(rendererController);
             });
           } else {
             if (options.code) {
@@ -92,23 +109,23 @@ function(tools, EventEmitter, URI) {
           if (options.code) {
             runnerContext.run(options.code);
           }
-          rendererController.emit('load');
+          onContextLoad(rendererController);
         });
       } else if (options.code) {
         runnerContext.run(options.code);
-        rendererController.emit('load');
+        onContextLoad(rendererController);
       }
 
       function loadAll(urls, cb) {
         var nUrls = urls.length,
             nLoaded = 0;
-        tools.forEach(urls, function(url) {
-          runnerContext.load(rendererController.baseUrl.resolveUri(url).toString());
-        });
         runnerContext.on('scriptLoaded', function(url) {
           if (++nLoaded === nUrls) {
             cb();
           }
+        });
+        tools.forEach(urls, function(url) {
+          runnerContext.load(rendererController.baseUrl.resolveUri(url).toString());
         });
       }
     },
@@ -310,6 +327,14 @@ function(tools, EventEmitter, URI) {
      * @returns {this} The instance
      */
     sendMessage: function(category, messageData) {
+      var pendingMessages = this._pendingMessages;
+      if (pendingMessages) {
+        // the context is not ready yet, queue all messages;
+        // pendingMessages is set to null as soon as the context can receive
+        pendingMessages.push(arguments);
+        return this;
+      }
+
       if (arguments.length < 2) {
         this.post('message', category);
       } else {

--- a/src/renderer/renderer_controller.js
+++ b/src/renderer/renderer_controller.js
@@ -46,6 +46,11 @@ function(tools, EventEmitter, URI) {
     this.runnerContext = runnerContext;
     this._movieOptions = this._cleanOptions(options);
     this.baseUrl = URI.parse(options.baseUrl);
+
+    /*
+      All user messages sent via `sendMessage()` are queued until the runner has
+      loaded completely. This ensures that a listener can be registered in time.
+     */
     this._pendingMessages = [];
 
     runnerContext.on('message', this, this.handleEvent);
@@ -328,6 +333,11 @@ function(tools, EventEmitter, URI) {
      */
     sendMessage: function(category, messageData) {
       var pendingMessages = this._pendingMessages;
+
+      /*
+        Before the runner context has loaded and is ready, pendingMessage is an
+        array. Afterwards, pendingMessage is set to null and the test will fail.
+      */
       if (pendingMessages) {
         // the context is not ready yet, queue all messages;
         // pendingMessages is set to null as soon as the context can receive

--- a/test/renderer_controller-spec.js
+++ b/test/renderer_controller-spec.js
@@ -37,7 +37,10 @@ define([
   }
 
   function createRendererController() {
-    return new RendererController(mockRenderer, mockAssetController, mockRunner, baseUri);
+    return new RendererController(mockRenderer, mockAssetController, mockRunner, {
+      baseUri: baseUri,
+      code: 'arbitrary(code)'
+    });
   }
 
   describe('RendererController', function () {

--- a/test/renderer_controller-spec.js
+++ b/test/renderer_controller-spec.js
@@ -450,10 +450,15 @@ define([
 
           runnerContextIsReady();
 
+          var category3 = 'arbitrary 2', message3 = {};
+          rendererController.sendMessage(category3, message3);
+
           expect(runnerContext.notifyRunner)
             .toHaveReceivedMessage(message1);
           expect(runnerContext.notifyRunner)
             .toHaveReceivedMessage(category2, message2);
+          expect(runnerContext.notifyRunner)
+            .toHaveReceivedMessage(category3, message3);
         }
 
         it('should defer sending messages if initialized with just an url', function() {

--- a/test/renderer_controller-spec.js
+++ b/test/renderer_controller-spec.js
@@ -25,7 +25,11 @@ define([
         this.emit('message', {command: 'init', data: 'listening'});
       }),
       notifyRunner: jasmine.createSpy('runner.notifyRunner'),
-      notifyRunnerAsync: jasmine.createSpy('runner.notifyRunnerAsync'),
+      notifyRunnerAsync: function() { this.notifyRunner.apply(this, arguments); },
+      load: function(url) {
+        this.emit('scriptLoaded', url);
+      },
+      run: function() {},
       destroy: jasmine.createSpy('runner.destroy')
     }, EventEmitter);
 
@@ -314,6 +318,7 @@ define([
       var rendererController;
       beforeEach(function() {
         rendererController = createRendererController();
+        rendererController.runnerContext.emit('message', {command: 'isReady'});
       });
       function getFirstArg() {
         return mockRunner.notifyRunner.mostRecentCall.args[0];
@@ -390,6 +395,85 @@ define([
         expect(categorizedListener).toHaveBeenCalledWith(messageData);
       });
 
+      describe('deferral until runner startup completion', function() {
+        beforeEach(function() {
+          this.addMatchers({
+            toHaveReceivedMessage: function(category, data) {
+              var spy = this.actual, calls = spy.calls;
+              var match = arguments.length < 2 ?
+                function(message) {
+                  return message &&
+                    message.command === 'message' &&
+                    message.data === category;
+                } :
+                function(message) {
+                  return message &&
+                    message.command === 'message' &&
+                    message.category === category &&
+                    message.data === data;
+                };
+
+              for (var i = 0, length = calls.length; i < length; i += 1) {
+                if (match(calls[i].args[0])) return true;
+              }
+              return false;
+            }
+          })
+        });
+
+        var rendererController, runnerContext;
+        function initRendererController(options) {
+          resetMocks();
+          rendererController = new RendererController(mockRenderer, mockAssetController, mockRunner, options);
+          runnerContext = rendererController.runnerContext;
+        }
+        function runnerContextIsReady() {
+          runnerContext.emit('message', {command: 'isReady'});
+        }
+
+        function testDeferral(options) {
+          initRendererController(options);
+
+          var message1 = {};
+          rendererController.sendMessage(message1);
+
+          var category2 = 'arbitrary', message2 = {};
+          rendererController.sendMessage(category2, message2);
+
+          expect(runnerContext.notifyRunner)
+            .not.toHaveReceivedMessage(message1);
+          expect(runnerContext.notifyRunner)
+            .not.toHaveReceivedMessage(category2, message2);
+
+          runnerContextIsReady();
+
+          expect(runnerContext.notifyRunner)
+            .toHaveReceivedMessage(message1);
+          expect(runnerContext.notifyRunner)
+            .toHaveReceivedMessage(category2, message2);
+        }
+
+        it('should defer sending messages if initialized with just an url', function() {
+          testDeferral({
+            url: 'foo.js'
+          });
+        });
+
+        it('should defer sending messages if initialized with only code', function() {
+          testDeferral({
+            code: 'stage.addChild(new Rect());'
+          });
+        });
+
+        it('should defer sending messages if initialized with plugins, urls, url, and code', function() {
+          testDeferral({
+            plugins: ['a.js', 'b.js', 'c.js'],
+            urls: ['d.js', 'e.js', 'f.js'],
+            url: 'g.js',
+            code: 'void arbitrary(stage);'
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This defers sending of user messages to the runner context through `sendMessage()` until the runner has started up and is able to receive them.

Would fix #154
