### PR TITLE
scaleX/scaleY updated when matrix is manipulated directly

### DIFF
--- a/src/runner/display_object.js
+++ b/src/runner/display_object.js
@@ -88,12 +88,16 @@ define([
 
   function setMatrix(matrix) {
     var m = this._matrix;
-    m.a = matrix.a;
+    m.a = this._scaleX = matrix.a;
     m.b = matrix.b;
     m.c = matrix.c;
-    m.d = matrix.d;
+    m.d = this._scaleY = matrix.d;
     m.tx = matrix.tx;
     m.ty = matrix.ty;
+
+    // this does not need to be set here since updating the
+    // _scaleX and _scaleY setters will do it
+    // this._owner._mutatedAttributes.matrix = true;
   }
 
   function getX() {

--- a/test/display_object-spec.js
+++ b/test/display_object-spec.js
@@ -124,6 +124,39 @@ define([
           expect(m.ty).toBe(-100);
         });
 
+        it('should set the scale properties when a matrix is updated', function () {
+          var d, m;
+          d = new DisplayObject();
+          m = new Matrix(2, 0, 0, 2, 0, 0);
+          d.attr('matrix', m);
+          expect(d.attr('scaleX')).toBe(2);
+          expect(d.attr('scaleY')).toBe(2);
+          expect(d.attr('scale')).toBe(2);
+
+          // reset
+          d.attr('scaleX', 1);
+          d.attr('scaleY', 1);
+          expect(d.attr('scaleX')).toBe(1);
+          expect(d.attr('scaleY')).toBe(1);
+          expect(d.attr('scale')).toBe(1);
+        });
+
+        it('should allow the matrix to be updated after setting a scale', function () {
+          var d, m;
+          d = new DisplayObject();
+          m = new Matrix(2, 0, 0, 3, 0, 0);
+
+          // scale up, then set the matrix
+          d.attr('scaleX', 1.5);
+          d.attr('scaleY', 2);
+          d.attr('matrix', m);
+
+          expect(d.attr('scaleX')).toBe(2);
+          expect(d.attr('scaleY')).toBe(3);
+
+          expect(d.attr('scale')).toBe((2 + 3) / 2);
+        });
+
       });
 
       it('should use the origin attribute for rotation', function() {


### PR DESCRIPTION
Fixes #162

I was hoping to simplify this down to be similar to the x/y getters and setters (manipulate the matrix directly), but my first attempt caused a large number of failing specs, so I opted for the double-setting in the `setMatrix` call instead.

I added some tests (didn’t push them) to ensure the same behavior for rotation, but they already passed. I could commit them to prevent potential regressions, but seeing as the rotation logic lives within the matrix class I didn’t think that was very likely.
