### PR TITLE
Prevent dom clutter

### DIFF
--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -57,19 +57,20 @@ define([
       fontPrefix = AssetController.handlers.Font.prefix;
 
   var basicAttributeMap = {
-    cap: 'stroke-linecap',
-    join: 'stroke-linejoin',
-    miterLimit: 'stroke-miterlimit',
-    opacity: 'opacity',
-    fillOpacity: 'fill-opacity',
-    strokeOpacity: 'stroke-opacity',
-    fontSize: 'font-size',
-    fontWeight: 'font-weight',
-    fontStyle: 'font-style',
-    textAnchor: 'text-anchor',
-    text: 'text',
-    cursor: 'cursor',
-    fillRule: 'fill-rule'
+    // bonsai attribute: [svg attribute, default value]
+    cap: ['stroke-linecap', 'butt'],
+    join: ['stroke-linejoin', 'miter'],
+    miterLimit: ['stroke-miterlimit', '4'],
+    opacity: ['opacity', '1'],
+    fillOpacity: ['fill-opacity', '1'],
+    strokeOpacity: ['stroke-opacity', '1'],
+    fontSize: ['font-size'],
+    fontWeight: ['font-weight'],
+    fontStyle: ['font-style'],
+    textAnchor: ['text-anchor', 'start'],
+    text: ['text'],
+    cursor: ['cursor', 'inherit'],
+    fillRule: ['fill-rule', 'inherit']
   };
 
   var eventTypes = [
@@ -146,10 +147,14 @@ define([
         value = attributes[i];
 
         if (i in basicAttributeMap) {
-          if (value != null) {
-            el.setAttribute(basicAttributeMap[i], value);
-          } else if (value === null) {
-            el.removeAttribute(basicAttributeMap[i]);
+          var attributeInfo = basicAttributeMap[i];
+          var attributeName = attributeInfo[0], defaultValue = attributeInfo[1];
+
+          var isInitalValue = '' + value === defaultValue;
+          if (value !== null && !isInitalValue) {
+            el.setAttribute(attributeName, value);
+          } else if (value === null || isInitalValue) {
+            el.removeAttribute(attributeName);
           }
           continue;
         }

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -20,6 +20,22 @@ define([
   // targets webkit based browsers from version 530.0 to 534.4
   var isWebkitPatternBug = /AppleWebKit\/53([0-3]|4.([0-4]))/.test(navigator.appVersion);
 
+  /**
+   * Sets a style property on a style object. Avoids unnecessary creation of
+   * style attributes in the DOM, to ease debugging.
+   *
+   * @param {CSSStyleDeclaration} style The style object to set the property on
+   * @param {string} name The name of the property to set
+   * @param {string} value The value of the property to set.
+   */
+  function setStyle(style, name, value) {
+    if (value) {
+      style[name] = value;
+    } else if (style[name]) { // only remove if set to prevent empty style attributes in the DOM
+      style[name] = '';
+    }
+  }
+
   // Math
   var min = Math.min;
   var max = Math.max;
@@ -140,16 +156,7 @@ define([
 
         switch (i) {
           case 'interactive':
-            if (value) {
-              // only set if it already contains something
-              // prevents useless "empty" style attrs in dom
-              // (default is inherit anyways)
-              if (el.style.pointerEvents) {
-                el.style.pointerEvents = '';
-              }
-            } else {
-              el.style.pointerEvents = 'none';
-            }
+            setStyle(el.style, 'pointerEvents', value ? '' : 'none');
             break;
           case 'fontFamily':
             value = fontIDs[value] || value;
@@ -515,7 +522,7 @@ define([
     }
 
     if (attr.visible != null) {
-      element.style.visibility = attr.visible ? '' : 'hidden';
+      setStyle(element.style, 'visibility', attr.visible ? '' : 'hidden');
     }
 
     if (type === 'Path' || type === 'Text' || type === 'TextSpan') {

--- a/src/renderer/svg/svg.js
+++ b/src/renderer/svg/svg.js
@@ -140,7 +140,16 @@ define([
 
         switch (i) {
           case 'interactive':
-            el.style.pointerEvents = value ? 'inherit' : 'none';
+            if (value) {
+              // only set if it already contains something
+              // prevents useless "empty" style attrs in dom
+              // (default is inherit anyways)
+              if (el.style.pointerEvents) {
+                el.style.pointerEvents = '';
+              }
+            } else {
+              el.style.pointerEvents = 'none';
+            }
             break;
           case 'fontFamily':
             value = fontIDs[value] || value;
@@ -179,10 +188,14 @@ define([
             break;
           case 'matrix':
             if (value != null) {
-              el.setAttribute(
-                'transform',
-                matrixToString(value)
-              );
+              // clear transform attribute for identity matrix
+              var strMatrix = matrixToString(value);
+              if (strMatrix == 'matrix(1,0,0,1,0,0)') {
+                // this is the default
+                el.removeAttribute('transform');
+              } else {
+                el.setAttribute('transform', strMatrix);
+              }
             } else if (value === null) {
               el.removeAttribute('transform');
             }


### PR DESCRIPTION
Removes `transform` for the identity matrix and `pointer-events` for the default of `inherit`. Maybe more props can be prevented but I think some are used elsewhere.
