### PR TITLE
Tree traversal

### DIFF
--- a/src/runner/display_list.js
+++ b/src/runner/display_list.js
@@ -150,22 +150,6 @@ define([
     }
   };
 
-  function activate(stage) {
-    DisplayObject.prototype._activate.call(this, stage);
-    var children = this.displayList.children;
-    for (var i = 0, length = children.length; i < length; i += 1) {
-      children[i]._activate(stage);
-    }
-  }
-
-  function deactivate() {
-    DisplayObject.prototype._deactivate.call(this);
-    var children = this.displayList.children;
-    for (var i = 0, length = children.length; i < length; i += 1) {
-      children[i]._deactivate();
-    }
-  }
-
   /**
    * Ready made methods that can be used by / mixed into objects owning a
    * display list and inherit from DisplayObject
@@ -180,14 +164,26 @@ define([
      * @param {Stage} stage
      * @private
      */
-    _activate: activate,
+    _activate: function(stage) {
+      DisplayObject.prototype._activate.call(this, stage);
+      var children = this.displayList.children;
+      for (var i = 0, length = children.length; i < length; i += 1) {
+        children[i]._activate(stage);
+      }
+    },
 
     /**
      * Deactivates the object and all of its children
      *
      * @private
      */
-    _deactivate: deactivate,
+    _deactivate: function() {
+      DisplayObject.prototype._deactivate.call(this);
+      var children = this.displayList.children;
+      for (var i = 0, length = children.length; i < length; i += 1) {
+        children[i]._deactivate();
+      }
+    },
 
     /**
      * Adds a child or an array of children to the object.
@@ -282,11 +278,8 @@ define([
     }
   };
 
-  var timelineMethods = tools.mixin({}, methods);
-
   return {
     DisplayList: DisplayList,
-    methods: methods,
-    timelineMethods: timelineMethods
+    methods: methods
   };
 });

--- a/src/runner/display_list.js
+++ b/src/runner/display_list.js
@@ -283,18 +283,6 @@ define([
   };
 
   var timelineMethods = tools.mixin({}, methods);
-  timelineMethods._activate = function(stage) {
-    activate.call(this, stage);
-    if (stage) {
-      stage.registry.movies.add(this);
-    }
-  };
-  timelineMethods._deactivate = function() {
-    if (this.stage) {
-      this.stage.registry.movies.remove(this);
-    }
-    deactivate.call(this);
-  };
 
   return {
     DisplayList: DisplayList,

--- a/src/runner/display_object.js
+++ b/src/runner/display_object.js
@@ -390,11 +390,6 @@ define([
     stage.registry.needsInsertion[obj.id] = obj;
     stage.registry.displayObjects[obj.id] = obj;
 
-    // Add submovie to movies registry so that it is "advanced" with all
-    // other sub-movies in stage#loop
-    if (obj.type === 'Movie') {
-      stage.registry.movies.add(obj);
-    }
     // Note: Current impl. of clip/mask relies on this (e.g. sub-clip applied to off-stage mask)
 
     if (!isChild) {

--- a/src/runner/movie.js
+++ b/src/runner/movie.js
@@ -21,7 +21,7 @@ define([
    *
    * @extends AssetDisplayObject
    * @mixes Timeline
-   * @mixes displayList.timelineMethods
+   * @mixes displayList.methods
    */
   function Movie(root, url, callback, displayList) {
     AssetDisplayObject.call(this, null, url, callback);
@@ -48,7 +48,7 @@ define([
   }
 
   var proto = Movie.prototype =
-    tools.mixin(Object.create(AssetDisplayObject.prototype), Timeline, displayList.timelineMethods);
+    tools.mixin(Object.create(AssetDisplayObject.prototype), Timeline, displayList.methods);
 
   proto.loadSubMovie = function() {
     return this.root.loadSubMovie.apply(this.root, arguments);

--- a/src/runner/registry.js
+++ b/src/runner/registry.js
@@ -5,20 +5,6 @@
 define(function() {
   'use strict';
 
-  function MovieRegistry() {
-    var movies = this.movies = [];
-
-    this.add = function(movie) {
-      if (movies.indexOf(movie) === -1) {
-        movies.push(movie);
-      }
-    };
-    this.remove = function(movie) {
-      var index = movies.indexOf(movie);
-      delete movies[index];
-    };
-  }
-
   /**
    * @constructor
    * @private
@@ -48,17 +34,6 @@ define(function() {
        * @type {object}
        */
       loadingDisplayObjects: Object.create(null),
-
-      /**
-       * Registry for Movie instances (sub-movies) within a bonsai movie.
-       *
-       * This map is used to advance every (currently playing) timeline when a
-       * frame is entered.
-       *
-       * @private
-       * @type {object}
-       */
-      movies: new MovieRegistry(),
 
       /**
        * Global Registry for display objects that need to be updated by renderer

--- a/src/runner/stage.js
+++ b/src/runner/stage.js
@@ -233,47 +233,15 @@ define([
      * @private
      */
     loop: function() {
-
-      this.emitFrame();
-
-      var registry = this.registry;
-      var movieRegistry = registry.movies;
-
-      var movies = tools.removeValueFromArray(movieRegistry.movies);
-
-      /*
-        The `movies` array may contain gaps (if elements are removed from the
-        stage during the iteration) and increase its length during the iteration
-        (if timelines are added to the stage during iteration)
-       */
-      var len, movie, i = 0;
-      while (i < len  // check whether we are within the cached length
-          || i < (len = movies.length)) { // check whether we are within the actual length and cache the length
-
-        movie = movies[i];
-        if (movie) {
-          movie.emitFrame();
-        }
-
-        i += 1;
-      }
-
+      this.playFrame();
 
       // Emit an event to mark the fact that we've emitted all submovies' frames:
       this.emit('subMoviesAdvanced');
 
-      var moviesToIncrement = [this].concat(movies);
-      // Go through all movies and increment their respective frames:
-      for (i = 0, len = moviesToIncrement.length; i < len; ++i) {
-        movie = moviesToIncrement[i];
-        if (movie && movie.isPlaying) {
-          movie.incrementFrame();
-        }
-      }
-
       var message;
       var messagesIndexesById = this._queuedFramesById;
       var queuedFrames = this._queuedFrames;
+      var registry = this.registry;
       var displayObjectRegistry = registry.displayObjects,
           needsDrawRegistry = registry.needsDraw,
           needsInsertionRegistry = registry.needsInsertion;

--- a/src/runner/stage.js
+++ b/src/runner/stage.js
@@ -235,9 +235,6 @@ define([
     loop: function() {
       this.playFrame();
 
-      // Emit an event to mark the fact that we've emitted all submovies' frames:
-      this.emit('subMoviesAdvanced');
-
       var message;
       var messagesIndexesById = this._queuedFramesById;
       var queuedFrames = this._queuedFrames;

--- a/src/runner/stage.js
+++ b/src/runner/stage.js
@@ -425,7 +425,7 @@ define([
     }
   };
 
-  tools.mixin(proto, EventEmitter, displayList.timelineMethods, Timeline);
+  tools.mixin(proto, EventEmitter, displayList.methods, Timeline);
   delete proto.markUpdate;
 
   return Stage;

--- a/src/runner/timeline.js
+++ b/src/runner/timeline.js
@@ -6,6 +6,10 @@ define([
 
   var round = Math.round;
 
+  function isTimeline(displayObject) {
+    return typeof displayObject.emitFrame === 'function';
+  }
+
   /**
    * The Timeline mixin. It contains timeline functionality (controls a series
    * of frames).
@@ -63,11 +67,13 @@ define([
       var children = displayList && displayList.children;
       var child = children && children[0];
       while (child) {
-        if (typeof child.emitFrame === 'function') {
+        if (isTimeline(child)) {
           child.emitFrame(advancedTimelines);
         }
         child = child.next;
       }
+
+      this.emit('tickEnd', this, currentFrame);
 
       return advancedTimelines;
     },

--- a/test/animation/animation-spec.js
+++ b/test/animation/animation-spec.js
@@ -33,7 +33,6 @@ define([
       this.interval = setInterval(
         tools.hitch(this, function() {
           this.emitFrame();
-          this.incrementFrame();
         }),
         this.framerate / 1000
       );

--- a/test/animation/keyframe_animation-spec.js
+++ b/test/animation/keyframe_animation-spec.js
@@ -26,7 +26,6 @@ define([
       this.interval = setInterval(
         tools.hitch(this, function() {
           this.emitFrame();
-          this.incrementFrame();
         }),
         this.framerate / 1000
       );

--- a/test/common/mock.js
+++ b/test/common/mock.js
@@ -47,10 +47,6 @@ define(function() {
       return {
         registry: {
           displayObjects: {},
-          movies: {
-            add: jasmine.createSpy('add'),
-            remove: jasmine.createSpy('remove')
-          },
           needsDraw: {},
           needsInsertion: {}
         }

--- a/test/movie-spec.js
+++ b/test/movie-spec.js
@@ -36,20 +36,6 @@ define([
         movie = new Movie(stage);
         movie.parent = mock.createDisplayObject();
       });
-      describe('_activate()', function() {
-        it('should add the movie to the movie registry', function() {
-          movie._activate(stage);
-          expect(registry.movies.add).toHaveBeenCalledWith(movie);
-        });
-      });
-      describe('_deactivate()', function() {
-        it('should remove the movie from the movie registry', function() {
-          movie._activate(stage);
-
-          movie._deactivate();
-          expect(registry.movies.remove).toHaveBeenCalled();
-        });
-      });
     });
 
   });

--- a/test/stage-spec.js
+++ b/test/stage-spec.js
@@ -250,6 +250,15 @@ define([
 
     });
 
+    describe('stage#loop()', function() {
+      it('should call the playFrame method of the stage', function() {
+        var stage = makeStage();
+        spyOn(stage, 'playFrame');
+        stage.loop();
+        expect(stage.playFrame).toHaveBeenCalled();
+      });
+    });
+
   });
 
 });

--- a/test/timeline-spec.js
+++ b/test/timeline-spec.js
@@ -336,7 +336,7 @@ define([
       expect(calls).toEqual([]);
     });
 
-    it('should call the `emitFrame` method of every child that has one after emitting the advance event', function() {
+    it('should call the `emitFrame` method of every child that is a timeline after emitting the advance event', function() {
       var calls = [];
       var child2 = {emitFrame: function() { calls.push(2); }};
       var child1 = {next: child2, emitFrame: function() { calls.push(1); }};
@@ -353,6 +353,29 @@ define([
       timeline.on('advance', function() { calls.push('advance'); });
       timeline[methodName]();
       expect(calls).toEqual(['advance', 0, 1, 2]);
+    });
+
+    it('should emit an "tickEnd" event after calling the emitFrame() of the last child', function() {
+      var lastChildPassed = false;
+      var emittedAfterPassingLastChild;
+      var currentFrame = timeline.currentFrame;
+
+      timeline.displayList = {
+        children: [
+          { emitFrame: function() { lastChildPassed = true; } }
+        ]
+      };
+
+      var onTickEnd = jasmine.createSpy().andCallFake(function() {
+        emittedAfterPassingLastChild = lastChildPassed === true;
+      });
+      timeline
+        .on('tickEnd', onTickEnd)
+        .emitFrame();
+
+      expect(emittedAfterPassingLastChild).toBe(true);
+      expect(onTickEnd).toHaveBeenCalledWith(timeline, currentFrame);
+
     });
   }
 });


### PR DESCRIPTION
- the emission of “tick” / “advance” / frame number events now happens in tree order (depth first) rather than insertion order.
- it also adds a “tickEnd” event for each timeline after all child timelines emitted their frame events.
- There is still optimization opportunity: `addChildren()` could maintain a child timeline array on each timeline instance to make iteration faster.
