### PR TITLE
Pointer events cleanup and alignment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ v0.4.3
 -------------------
 * Add support for `strokeDash` and `strokeDashOffset` attributes on all Paths.
 * Add `DisplayObject#globalToLocal()` and `DisplayObject#localToGlobal()`
+* Consistent delivery of diffX/Y and deltaX/Y offsets for move and drag events
 
 v0.4.2 / 2013-01-14
 -------------------

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -194,10 +194,7 @@ define([
           targetId = data._dragId;
           event.diffX = clientX - start[0];
           event.diffY = clientY - start[1];
-          delete data._currentTouch;
-          delete data._dragId;
-          delete data._startEventPos;
-          delete data._lastEventPos;
+          data._dragId = data._startEventPos = data._lastEventPos = null;
           type = 'pointerup';
           break;
 

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -205,6 +205,11 @@ define([
           break;
 
         case 'mousemove':
+          event.diffX = clientX - start[0];
+          event.diffY = clientY - start[1];
+          event.deltaX = clientX - last[0];
+          event.deltaY = clientY - last[1];
+
           // Regular mousemove event (not dragging)
           (event = cloneBasicEvent(event)).type = 'pointermove';
           this.emit('userevent', event, targetId);
@@ -213,10 +218,6 @@ define([
           this.emit('userevent', event, targetId);
 
           targetId = data._dragId;
-          event.diffX = clientX - start[0];
-          event.diffY = clientY - start[1];
-          event.deltaX = clientX - last[0];
-          event.deltaY = clientY - last[1];
           if (targetId !== null) {
             type = 'drag';
           } else {

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -85,6 +85,8 @@ define([
         case 'touchmove':
           event.diffX = clientX - touchData.startX;
           event.diffY = clientY - touchData.startY;
+          event.deltaX = clientX - touchData.lastX;
+          event.deltaY = clientY - touchData.lastY;
           touchData.touchMoveHappened = true;
           event = cloneBasicEvent(event);
           event.type = prefix + 'drag';
@@ -107,6 +109,7 @@ define([
             event.type = 'click';
             this.emit('userevent', event, targetId);
           }
+          break;
       }
     },
 
@@ -136,6 +139,10 @@ define([
           if (i === 0) {
             this.handleSingleTouch(touch, singleTouchData, false);
           }
+
+          // set lastX/Y at the very end -- touches might be handled to handleSingleTouch multiple times
+          singleTouchData.lastX = touch.clientX;
+          singleTouchData.lastY = touch.clientY;
         }
       }
 

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -171,12 +171,13 @@ define([
       var last = data._lastEventPos || [clientX, clientY];
       var start = data._startEventPos || [clientX, clientY];
 
-      if (/^touch/.test(domEvent.type)) {
-        this.handleTouchEvent(domEvent);
-        return;
-      }
-
       switch (type) {
+        case 'touchstart':
+        case 'touchmove':
+        case 'touchend':
+        case 'touchcancel':
+          this.handleTouchEvent(domEvent);
+          return;
 
         case 'dblclick':
           type = 'doubleclick';

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -213,11 +213,15 @@ define([
           this.emit('userevent', event, targetId);
 
           targetId = data._dragId;
-          type = 'drag';
           event.diffX = clientX - start[0];
           event.diffY = clientY - start[1];
           event.deltaX = clientX - last[0];
           event.deltaY = clientY - last[1];
+          if (targetId !== null) {
+            type = 'drag';
+          } else {
+            return;
+          }
           break;
         case 'keypress':
           type = 'key';

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -138,6 +138,10 @@ define([
           }
         }
       }
+
+      if (type === 'touchend' && allTouches.length === 0) {
+        this.touchData = {};
+      }
     },
 
     handleEvent: function(domEvent) {

--- a/src/renderer/svg/svg_event_handlers.js
+++ b/src/renderer/svg/svg_event_handlers.js
@@ -189,7 +189,6 @@ define([
           event.delta = domEvent.wheelDelta;
           break;
 
-        case 'touchend':
         case 'mouseup':
           targetId = data._dragId;
           event.diffX = clientX - start[0];
@@ -201,22 +200,12 @@ define([
           type = 'pointerup';
           break;
 
-        case 'touchstart':
-          if (data._currentTouch) {
-            // Don't allow other touches while once has yet to end.
-            return;
-          }
-          data._currentTouch = domEvent.touches[0].identifier;
         case 'mousedown':
           data._dragId = targetId;
           data._startEventPos = [clientX, clientY];
           type = 'pointerdown';
           break;
 
-        case 'touchmove':
-          if (domEvent.touches[0].identifier !== data._currentTouch) {
-            return;
-          }
         case 'mousemove':
           // Regular mousemove event (not dragging)
           (event = cloneBasicEvent(event)).type = 'pointermove';


### PR DESCRIPTION
- Cleans up event handling in the svg renderer.
- adds “deltaX/Y” and “diffX/Y” to regular “pointermove” events as well (not only drags) when triggered by mouse events.
- adds “deltaX/Y” to “pointermove” and “drag” events when triggered by touches
- does not send unnecessary drag events to the runner.
- Stops memory leaking from touch events.
