### PR TITLE
EventEmitter: Fix emit/once edge case

### DIFF
--- a/src/event_emitter.js
+++ b/src/event_emitter.js
@@ -4,8 +4,7 @@ define([
 
   'use strict';
 
-  var slice = [].slice,
-      split = ''.split;
+  var split = ''.split;
 
   function Listener(context, listener, times) {
     this.context = context;

--- a/src/event_emitter.js
+++ b/src/event_emitter.js
@@ -149,15 +149,16 @@ define([
         context = listener.context;
         listenerFunc = listener.listener;
 
-        if (typeof listenerFunc === 'string') {
-          listenerFunc = context[listenerFunc];
-        }
-        listenerFunc.apply(context || this, args);
-
         listenerTimes = listener.times -= 1;
         if (listenerTimes <= 0) {
           this.removeListener(type, context, listener.listener);
         }
+
+        if (typeof listenerFunc === 'string') {
+          listenerFunc = context[listenerFunc];
+        }
+
+        listenerFunc.apply(context || this, args);
       }
 
       return this;

--- a/test/event_emitter-spec.js
+++ b/test/event_emitter-spec.js
@@ -264,6 +264,19 @@ define([
           expect(remove).not.toHaveBeenCalled();
         }
       );
+
+      it('should not invoke a listener within its own callback added through `once`', function() {
+        var e = emitter;
+        var callCount = 0;
+
+        e.once('foo', function() {
+          callCount++;
+          e.emit('foo');
+        });
+        e.emit('foo');
+
+        expect(callCount).toBe(1);
+      });
     });
 
     describe('removeListener', function() {


### PR DESCRIPTION
This PR fixes a bug in `EventEmitter` where a Listener added via `once` is not removed correctly.

This example results in an infinite loop.

```
obj.once('play', function() {
  obj.play();
})
```
