### PR TITLE
Fixes #191. Add “smoothCurveTo/By` support to CurvedPath.toCurves`

### DIFF
--- a/src/runner/path/curved_path.js
+++ b/src/runner/path/curved_path.js
@@ -27,6 +27,7 @@ define([
    */
   function CurvedPath() {
     this._segments = [];
+    this._currentSegment = null;
     this.requiredCurves = 0;
     this.currentPoint = new Point(0, 0);
     this.lastMoveTo = new Point(0, 0);
@@ -49,6 +50,7 @@ define([
     var segment = [].slice.call(arguments);
     segment.from = this.currentPoint.clone();
     segment.lastMoveTo = this.lastMoveTo.clone();
+    this._currentSegment = segment;
     this._segments.push(segment);
     return this;
   };
@@ -203,6 +205,31 @@ define([
       cpy + currentPoint.y,
       x + currentPoint.x,
       y + currentPoint.y
+    );
+  };
+
+  // Based on: http://stackoverflow.com/questions/5287559/calculating-control-points-for-a-shorthand-smooth-svg-path-bezier-curve
+  proto.smoothCurveTo = function(cpx, cpy, endX, endY) {
+    var cp1x, cp1y;
+    var currentSegment = this._currentSegment;
+
+    // Don't draw curve in case previous segment is a "moveTo" or "closePath".
+    if (currentSegment !== null && currentSegment[0] === 'curveTo') {
+      cp1x = 2 * currentSegment[5] - currentSegment[3];
+      cp1y = 2 * currentSegment[6] - currentSegment[4];
+      this._push('curveTo', cp1x, cp1y, cpx, cpy, endX, endY);
+      this.currentPoint = new Point(endX, endY);
+    }
+    return this;
+  };
+
+  proto.smoothCurveBy = function(cpx, cpy, endX, endY) {
+    var currentPoint = this.currentPoint;
+    return this.smoothCurveTo(
+      cpx + currentPoint.x,
+      cpy + currentPoint.y,
+      endX + currentPoint.x,
+      endY + currentPoint.y
     );
   };
 

--- a/test/curved_path-spec.js
+++ b/test/curved_path-spec.js
@@ -258,6 +258,104 @@ define([
         expect(CurvedPath.toCurves([2])).toEqual([]);
       });
 
+      describe('parses `smoothCurveTo`', function() {
+
+        it('ignores call when previous segment does not exists', function() {
+          expect(CurvedPath.toCurves([
+            ['smoothCurveTo', 150, 100, 200, 200]
+          ])).toEqual([]);
+        });
+        it('ignores call when previous segment is a "moveTo"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['moveTo', 50, 50],
+              ['smoothCurveTo', 150, 100, 200, 200]
+            ]),
+            [
+              ['moveTo', 50, 50]
+            ]
+          );
+          expectEqualSegments(
+            new CurvedPath().moveTo(50, 50).smoothCurveTo(150, 100, 200, 200)._segments,
+            [
+              ['moveTo', 50, 50]
+            ]
+          );
+        });
+        it('ignores call when previous segment is a "closePath"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['moveTo', 50, 50],
+              ['closePath'],
+              ['smoothCurveTo', 150, 100, 200, 200]
+            ]),
+            [
+              ['moveTo', 50, 50],
+              ['closePath']
+            ]
+          );
+        });
+        it('parses when previous segment is a "curveTo"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['curveTo', 100, 100, 200, 200, 300, 300],
+              ['smoothCurveTo', 400, 400, 500, 500]
+            ]),
+            [
+              ['curveTo', 100, 100, 200, 200, 300, 300],
+              ['curveTo', 400, 400, 400, 400, 500, 500]
+            ]
+          );
+        });
+
+      });
+
+      describe('parses `smoothCurveBy`', function() {
+
+        it('ignores call when previous segment does not exists', function() {
+          expect(CurvedPath.toCurves([
+            ['smoothCurveBy', 150, 100, 200, 200]
+          ])).toEqual([]);
+        });
+        it('ignores call when previous segment is a "moveTo"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['moveTo', 50, 50],
+              ['smoothCurveBy', 150, 100, 200, 200]
+            ]),
+            [
+              ['moveTo', 50, 50]
+            ]
+          );
+        });
+        it('ignores call when previous segment is a "closePath"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['moveTo', 50, 50],
+              ['closePath'],
+              ['smoothCurveBy', 150, 100, 200, 200]
+            ]),
+            [
+              ['moveTo', 50, 50],
+              ['closePath']
+            ]
+          );
+        });
+        it('parses when previous segment is a "curveTo"', function() {
+          expectEqualSegments(
+            CurvedPath.toCurves([
+              ['curveTo', 100, 100, 200, 200, 300, 300],
+              ['smoothCurveBy', 400, 400, 500, 500]
+            ]),
+            [
+              ['curveTo', 100, 100, 200, 200, 300, 300],
+              ['curveTo', 400, 400, 700, 700, 800, 800]
+            ]
+          );
+        });
+
+      });
+
       it('Returns required amount of segments (via requiredCurves argument)', function() {
         expectEqualSegments(
           CurvedPath.toCurves([
@@ -421,6 +519,7 @@ define([
             ['curveTo', 400, 250, 400, 250, 400, 250] // nullSegment
           ]
         );
+
       });
 
     });


### PR DESCRIPTION
This PR allows animated Path using the "S" and "s" SVG shorthand commands. 
Fixes #191 

Example code:

```
var shape = new Path('M 321.051,510.078 c 0,0-10.126-23.854-19.438-45.792 c -7.927-18.675-15.265-35.961-15.265-35.961 s -17.977-41.111-19.036-77.643 c -1.05-36.243,14.817-67.908,14.817-67.908 s -36.176,73.71-49.086,137.219 c -9.327,45.879,3.426,87.39,3.426,87.39 z').attr({fillColor: 'red'});
stage.addChild(shape);

var targetPath = new Path('M 321.75,515.816 c 0,0,8.678-42.28,0.604-77.096 c -8.102-34.936-32.956-62.408-32.956-62.408 l -76.102-96.41c0,0-39.866-41.142-45.55-84.785 c -4.992-38.332,24.108-79.856,24.108-79.856 s -55.379,72.451-63.818,141.683 c -6.186,50.745,33.857,104.106,33.857,104.106 s 36.746,38.732,51.061,75.346 c 13.283,33.975,4.212,66.029,4.212,66.029 z').attr({fillColor: 'blue'});

shape.morphTo(targetPath, '3s');
```
